### PR TITLE
refactor: Button 컴포넌트에 as prop 적용 및 MainPage 사용 방식 업데이트, @emotion/rea…

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -2,19 +2,22 @@ import { css } from "@emotion/react";
 import { btnStyles } from "./btnStylesMap";
 
 const Button = ({
+  as: Component = "button",
   variant = "primary",
   size = "md",
   children,
   disabled,
   onClick,
+  ...resProps
 }) => (
-  <button
+  <Component
     css={ButtonStyle({ size, variant, disabled })}
-    disabled={disabled}
+    disabled={Component === "button" ? disabled : undefined}
+    {...resProps}
     onClick={onClick}
   >
     {children}
-  </button>
+  </Component>
 );
 
 export default Button;

--- a/src/pages/Main/components/MainPage.jsx
+++ b/src/pages/Main/components/MainPage.jsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import cardPreview from "../../../assets/images/card_preview.png";
 import emojiPreview from "../../../assets/images/emoji_preview.png";
@@ -43,14 +42,17 @@ const MainPage = () => {
           image={emojiPreview}
           reverse
         />
-
         {/* 구경해보기 버튼 */}
-        <div css={[customButtonWrapper, responsiveBox]}>
-          <Link to="/list" css={{ width: "100%", height: "100%" }}>
-            <Button variant="primary" size="lg">
-              구경해보기
-            </Button>
-          </Link>
+        <div css={[responsiveBox, flexCenter]}>
+          <Button
+            as={Link}
+            to="/list"
+            css={ctaButton}
+            variant="primary"
+            size="lg"
+          >
+            구경해보기
+          </Button>
         </div>
       </div>
     </>
@@ -60,30 +62,23 @@ export default MainPage;
 
 // 헤더 우측에 노출되는 "롤링 페이퍼 만들기" 버튼
 const HeaderButton = () => (
-  <Link
+  <Button
+    as={Link}
     to="/post"
+    variant="outlined"
+    size="md"
     css={css`
       width: 157px;
       height: 40px;
       display: block;
-
-      @media (max-width: ${BREAKPOINTS.sm}px) {
+      @media (max-width: ${BREAKPOINTS.md}px) {
         width: 142px;
-      }
-
-      & > button {
-        width: 100% !important;
-        height: 100% !important;
-        @media (max-width: ${BREAKPOINTS.sm}px) {
-          font-size: var(--font-size-14) !important;
-        }
+        font-size: var(--font-size-14);
       }
     `}
   >
-    <Button variant="outlined" size="md">
-      롤링 페이퍼 만들기
-    </Button>
-  </Link>
+    롤링 페이퍼 만들기
+  </Button>
 );
 
 // Point.01, Point.02 공통 영역 컴포넌트
@@ -246,36 +241,19 @@ const breakLine = css`
 
 export const responsiveBox = css`
   width: 100%;
-  max-width: 320px;
-
-  @media (min-width: ${BREAKPOINTS.md}px) {
-    max-width: 720px;
-  }
-  @media (min-width: ${BREAKPOINTS.lg}px) {
-    max-width: 1200px;
-  }
+  max-width: clamp(320px, 90vw, 1200px);
 `;
 
 // 하단 '구경해보기' 버튼 스타일 (정렬 + 반응형 너비)
-const customButtonWrapper = css`
-  max-width: 320px;
+const ctaButton = css`
   width: 100%;
   height: 56px;
   margin-top: 24px;
-
-  a {
-    display: flex;
-    justify-content: center;
-  }
-
-  button {
-    width: 100% !important;
-    height: 100% !important;
-    font-size: var(--font-size-18) !important;
-    font-weight: 700 !important;
-    @media (min-width: ${BREAKPOINTS.lg}px) {
-      max-width: 280px;
-    }
+  font-size: var(--font-size-18);
+  font-weight: 700;
+  @media (min-width: ${BREAKPOINTS.lg}px) {
+    max-width: 280px;
+    margin-top: 0;
   }
 `;
 
@@ -285,4 +263,10 @@ const reverseStyle = css`
     flex-direction: row-reverse;
     padding: 60px 60px 60px 0;
   }
+`;
+
+const flexCenter = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;


### PR DESCRIPTION
## 📝 요약(Summary)
- Button 컴포넌트가 as prop을 받아 <a> 태그 등 다른 요소로도 유연하게 사용할 수 있도록 내부 로직을 수정했습니다. (기본값은 button입니다)
- to, href 등 추가적인 속성도 전달되도록 처리했습니다.
- button 태그가 아닐 경우 disabled 속성에서 오류가 발생하지 않도록 조건부 렌더링으로 방지했습니다.
- 반응형 구간이 뚝뚝 끊기는 느낌을 개선하기 위해 clamp 속성으로 max-width를 설정했습니다.

## 💬 공유사항 to 리뷰어

- Button 컴포넌트 수정 방향이 괜찮은지 확인 부탁드립니다.
- 반응형 레이아웃 및 여백 부분은 이후에도 지속적으로 개선해나갈 예정입니다.
- 버튼 작업하고 계시는 만재님, 상달님을 리뷰어로 등록했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ x ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ x ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
