### PR TITLE
[Modal-PR2] Feature: Modal 상세 기능 추가, MessageCard 구조 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "nanoid": "^5.1.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.1"
@@ -2529,22 +2530,20 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -2722,6 +2721,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "nanoid": "^5.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.1"

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -56,11 +56,12 @@ export const MessageCardProfile = ({
   font,
   customCss,
 }) => {
+  const profileStyles = customCss
+    ? [MessageCardProfileStyle, customCss]
+    : [MessageCardProfileStyle];
+
   return (
-    <div
-      className="sender-profile-wrap"
-      css={[MessageCardProfileStyle, customCss]}
-    >
+    <div className="sender-profile-wrap" css={profileStyles}>
       <Avatar imgSrc={profileImageURL} size="md" />
       <div className="sender-profile" style={{ fontFamily: font }}>
         <span className="sender-name">
@@ -76,16 +77,24 @@ export const MessageCardProfile = ({
 };
 
 export const MessageCardContent = ({ content, customCss }) => {
+  const contentStyles = customCss
+    ? [MessageCardProfileStyle, customCss]
+    : [MessageCardProfileStyle];
+
   return (
-    <p className="content" css={[MessageCardContentStyle, customCss]}>
+    <p className="content" css={contentStyles}>
       {content}
     </p>
   );
 };
 
 export const MessageCardCreatedAt = ({ createdAt, customCss }) => {
+  const createdAtStyles = customCss
+    ? [MessageCardProfileStyle, customCss]
+    : [MessageCardProfileStyle];
+
   return (
-    <span className="createdAt" css={[MessageCardCreatedAtStyle, customCss]}>
+    <span className="createdAt" css={createdAtStyles}>
       {formatDate(createdAt)}
     </span>
   );

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -29,7 +29,7 @@ const MessageCard = ({
   return (
     <div css={MessageCardStyle} onClick={() => openModal(messageData)}>
       <div className="card-header">
-        <MessageCard.profile
+        <MessageCard.Profile
           sender={sender}
           profileImageURL={profileImageURL}
           relationship={relationship}
@@ -38,10 +38,10 @@ const MessageCard = ({
         {isEditable && <IconDeleteButton onClick={handleDelete} />}
       </div>
       <div className="card-body">
-        <MessageCardContent content={content} />
+        <MessageCard.Content content={content} />
       </div>
       <div className="card-footer">
-        <MessageCard.createdAt createdAt={createdAt} />
+        <MessageCard.CreatedAt createdAt={createdAt} />
       </div>
     </div>
   );
@@ -78,8 +78,8 @@ export const MessageCardProfile = ({
 
 export const MessageCardContent = ({ content, customCss }) => {
   const contentStyles = customCss
-    ? [MessageCardProfileStyle, customCss]
-    : [MessageCardProfileStyle];
+    ? [MessageCardContentStyle, customCss]
+    : [MessageCardContentStyle];
 
   return (
     <p className="content" css={contentStyles}>
@@ -90,8 +90,8 @@ export const MessageCardContent = ({ content, customCss }) => {
 
 export const MessageCardCreatedAt = ({ createdAt, customCss }) => {
   const createdAtStyles = customCss
-    ? [MessageCardProfileStyle, customCss]
-    : [MessageCardProfileStyle];
+    ? [MessageCardCreatedAtStyle, customCss]
+    : [MessageCardCreatedAtStyle];
 
   return (
     <span className="createdAt" css={createdAtStyles}>
@@ -100,6 +100,6 @@ export const MessageCardCreatedAt = ({ createdAt, customCss }) => {
   );
 };
 
-MessageCard.profile = MessageCardProfile;
-MessageCard.content = MessageCardContent;
-MessageCard.createdAt = MessageCardCreatedAt;
+MessageCard.Profile = MessageCardProfile;
+MessageCard.Content = MessageCardContent;
+MessageCard.CreatedAt = MessageCardCreatedAt;

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -1,4 +1,8 @@
-import MessageCardStyle from "./MessageCardStyle";
+import MessageCardStyle, {
+  MessageCardCreatedAtStyle,
+  MessageCardContentStyle,
+  MessageCardProfileStyle,
+} from "./MessageCardStyle";
 import Avatar from "../Avatar";
 import { IconDeleteButton } from "./../Button/IconButtons";
 import formatDate from "../../utils/formatDate";
@@ -21,28 +25,68 @@ const MessageCard = ({ messageData = {}, isEditable = false, openModal }) => {
   return (
     <div css={MessageCardStyle} onClick={() => openModal(messageData)}>
       <div className="card-header">
-        <div className="sender-profile-wrap">
-          <Avatar imgSrc={profileImageURL} size="md" />
-          <div className="sender-profile" style={{ fontFamily: font }}>
-            <span className="name">
-              From. <b>{sender}</b>
-            </span>
-            <span className="relationship">
-              {/* badge 컴포넌트로 교체 예정 */}
-              {relationship}
-            </span>
-          </div>
-        </div>
+        <MessageCard.profile
+          sender={sender}
+          profileImageURL={profileImageURL}
+          relationship={relationship}
+          font={font}
+        />
         {isEditable && <IconDeleteButton onClick={handleDelete} />}
       </div>
       <div className="card-body">
-        <p className="content">{content}</p>
+        <MessageCardContent content={content} />
       </div>
       <div className="card-footer">
-        <span className="date">{formatDate(createdAt)}</span>
+        <MessageCard.createdAt createdAt={createdAt} />
       </div>
     </div>
   );
 };
 
 export default MessageCard;
+
+export const MessageCardProfile = ({
+  profileImageURL,
+  sender,
+  relationship,
+  font,
+  customCss,
+}) => {
+  return (
+    <div
+      className="sender-profile-wrap"
+      css={[MessageCardProfileStyle, customCss]}
+    >
+      <Avatar imgSrc={profileImageURL} size="md" />
+      <div className="sender-profile" style={{ fontFamily: font }}>
+        <span className="sender-name">
+          From. <b>{sender}</b>
+        </span>
+        <span className="relationship">
+          {/* badge 컴포넌트로 교체 예정 */}
+          {relationship}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export const MessageCardContent = ({ content, customCss }) => {
+  return (
+    <p className="content" css={[MessageCardContentStyle, customCss]}>
+      {content}
+    </p>
+  );
+};
+
+export const MessageCardCreatedAt = ({ createdAt, customCss }) => {
+  return (
+    <span className="createdAt" css={[MessageCardCreatedAtStyle, customCss]}>
+      {formatDate(createdAt)}
+    </span>
+  );
+};
+
+MessageCard.profile = MessageCardProfile;
+MessageCard.content = MessageCardContent;
+MessageCard.createdAt = MessageCardCreatedAt;

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -7,7 +7,11 @@ import Avatar from "../Avatar";
 import { IconDeleteButton } from "./../Button/IconButtons";
 import formatDate from "../../utils/formatDate";
 
-const MessageCard = ({ messageData = {}, isEditable = false, openModal }) => {
+const MessageCard = ({
+  messageData = {},
+  isEditable = false,
+  openModal = () => {},
+}) => {
   const {
     sender,
     profileImageURL,

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -3,7 +3,7 @@ import Avatar from "../Avatar";
 import { IconDeleteButton } from "./../Button/IconButtons";
 import formatDate from "../../utils/formatDate";
 
-const MessageCard = ({ messageData = {}, isEditable = false }) => {
+const MessageCard = ({ messageData = {}, isEditable = false, openModal }) => {
   const {
     sender,
     profileImageURL,
@@ -19,10 +19,7 @@ const MessageCard = ({ messageData = {}, isEditable = false }) => {
   };
 
   return (
-    <div
-      css={MessageCardStyle}
-      onClick={() => alert("CardViewModal will be opened")}
-    >
+    <div css={MessageCardStyle} onClick={() => openModal(messageData)}>
       <div className="card-header">
         <div className="sender-profile-wrap">
           <Avatar imgSrc={profileImageURL} size="md" />

--- a/src/components/MessageCard/MessageCardList.jsx
+++ b/src/components/MessageCard/MessageCardList.jsx
@@ -8,7 +8,7 @@ import AddMessageCardButton from "./AddMessageCardButton";
 const MessageCardList = ({
   messages = [],
   editMode = false,
-  openMessageCardModal,
+  openMessageCardModal = () => {},
 }) => {
   if (!messages || messages.length === 0) {
     return <EmptyMessageCardList editMode={editMode} />;

--- a/src/components/MessageCard/MessageCardList.jsx
+++ b/src/components/MessageCard/MessageCardList.jsx
@@ -5,24 +5,36 @@ import AddMessageCardButton from "./AddMessageCardButton";
 /**
  * @param {boolean} editMode - 편집 모드
  */
-const MessageCardList = ({ messages = [], editMode = false }) => {
+const MessageCardList = ({
+  messages = [],
+  editMode = false,
+  openMessageCardModal,
+}) => {
   if (!messages || messages.length === 0) {
     return <EmptyMessageCardList editMode={editMode} />;
   }
 
   // 메시지가 1개 이상이고, 편집 모드가 아니면 메시지 리스트 보여주기
-  return <CardListResult messages={messages} editMode={editMode} />;
+  return (
+    <CardListResult
+      messages={messages}
+      editMode={editMode}
+      openModal={openMessageCardModal}
+    />
+  );
 };
 
-function CardListResult({ messages, editMode }) {
+function CardListResult({ messages, editMode, openModal }) {
   return (
     <div css={MessageCardListStyle}>
       {!editMode && <AddMessageCardButton />}
       {messages.map((message) => (
         <MessageCard
           key={message.id}
+          id={message.id}
           messageData={message}
           isEditable={editMode}
+          openModal={openModal}
         />
       ))}
     </div>

--- a/src/components/MessageCard/MessageCardStyle.js
+++ b/src/components/MessageCard/MessageCardStyle.js
@@ -5,7 +5,6 @@ const MessageCardStyle = css`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: 230px;
   padding: 28px 24px 24px;
   background-color: var(--white);
   border-radius: var(--radius-lg);
@@ -29,44 +28,51 @@ const MessageCardStyle = css`
     border-bottom: 1px solid var(--gray-200);
   }
 
-  .sender-profile-wrap {
-    display: flex;
-    gap: 14px;
-
-    .sender-profile {
-      .name {
-        display: block;
-        font-size: var(--font-size-20);
-      }
-    }
-  }
-
   .card-body {
-    height: 100%;
-  }
-
-  .content {
-    height: 56px;
-    margin-bottom: 16px;
-    padding-top: 16px;
-    font-size: var(--font-size-15);
-    color: var(--gray-600);
-    display: -webkit-box;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
-
-    @media (min-width: ${BREAKPOINTS.md}px) {
-      height: 100px;
-      font-size: var(--font-size-18);
-    }
-  }
-
-  .date {
-    font-size: var(--font-size-12);
-    color: var(--gray-400);
+    min-height: 110px;
   }
 `;
 
 export default MessageCardStyle;
+
+export const MessageCardProfileStyle = css`
+  display: flex;
+  gap: 10px;
+
+  .sender-name {
+    display: block;
+    font-size: var(--font-size-18);
+  }
+
+  @media (min-width: ${BREAKPOINTS.md}px) {
+    gap: 14px;
+
+    .sender-name {
+      font-size: var(--font-size-20);
+    }
+  }
+`;
+
+export const MessageCardContentStyle = css`
+  height: 56px;
+  margin-bottom: 16px;
+  padding-top: 16px;
+  font-size: var(--font-size-15);
+  color: var(--gray-600);
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+
+  @media (min-width: ${BREAKPOINTS.md}px) {
+    height: 100px;
+    font-size: var(--font-size-18);
+    -webkit-line-clamp: 3;
+  }
+`;
+
+export const MessageCardCreatedAtStyle = css`
+  font-size: var(--font-size-12);
+  color: var(--gray-400);
+`;

--- a/src/components/Modal/MessageCardModal.jsx
+++ b/src/components/Modal/MessageCardModal.jsx
@@ -1,0 +1,64 @@
+import { css } from "@emotion/react";
+import Button from "../Button";
+import {
+  MessageCardProfile,
+  MessageCardContent,
+  MessageCardCreatedAt,
+} from "../MessageCard/MessageCard";
+import Modal from "./Modal";
+import useModal from "./useModal";
+
+const MessageCardModal = ({ data }) => {
+  const { profileImageURL, sender, relationship, content, font, createdAt } =
+    data;
+  const { hideModal, modals } = useModal();
+
+  // 현재 컴포넌트에 해당하는 모달 ID 찾기
+  const currentModal = modals.find(
+    (modal) =>
+      modal.element?.type === MessageCardModal &&
+      modal.element?.props?.data === data
+  );
+
+  const handleClose = () => {
+    if (currentModal) {
+      hideModal(currentModal.id);
+    }
+  };
+
+  return (
+    <>
+      <Modal.header>
+        <MessageCardProfile
+          sender={sender}
+          profileImageURL={profileImageURL}
+          relationship={relationship}
+          font={font}
+        />
+        <MessageCardCreatedAt
+          createdAt={createdAt}
+          customCss={css`
+            font-size: var(--font-size-14);
+          `}
+        />
+      </Modal.header>
+      <Modal.divider />
+      <Modal.body>
+        <MessageCardContent
+          content={content}
+          customCss={css`
+            overflow: visible;
+            -webkit-line-clamp: initial;
+          `}
+        />
+      </Modal.body>
+      <Modal.actions>
+        <Button variant="primary" size="md" onClick={handleClose}>
+          확인
+        </Button>
+      </Modal.actions>
+    </>
+  );
+};
+
+export default MessageCardModal;

--- a/src/components/Modal/MessageCardModal.jsx
+++ b/src/components/Modal/MessageCardModal.jsx
@@ -17,7 +17,7 @@ const MessageCardModal = ({ data }) => {
   const currentModal = modals.find(
     (modal) =>
       modal.element?.type === MessageCardModal &&
-      modal.element?.props?.data === data
+      modal.element?.props?.data.id === data.id
   );
 
   const handleClose = () => {

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -3,7 +3,7 @@ import { BREAKPOINTS } from "../../constants/constants";
 
 const Modal = ({ children, visible }) => {
   return (
-    <div css={ModalStyle} className={`${visible && "visible"} modal`}>
+    <div css={ModalStyle} className={`modal ${visible ? "visible" : ""}`}>
       <div className="modal-content">{children}</div>
     </div>
   );

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,47 +1,10 @@
 import { css } from "@emotion/react";
-import Button from "../Button";
-import {
-  MessageCardProfile,
-  MessageCardContent,
-  MessageCardCreatedAt,
-} from "../MessageCard/MessageCard";
 import { BREAKPOINTS } from "../../constants/constants";
 
-const Modal = ({ data, visible, onClose }) => {
-  const { profileImageURL, sender, relationship, content, font, createdAt } =
-    data;
-
+const Modal = ({ children, visible }) => {
   return (
     <div css={ModalStyle} className={`${visible && "visible"} modal`}>
-      <Modal.header>
-        <MessageCardProfile
-          sender={sender}
-          profileImageURL={profileImageURL}
-          relationship={relationship}
-          font={font}
-        />
-        <MessageCardCreatedAt
-          createdAt={createdAt}
-          customCss={css`
-            font-size: var(--font-size-14);
-          `}
-        />
-      </Modal.header>
-      <Modal.divider />
-      <Modal.body>
-        <MessageCardContent
-          content={content}
-          customCss={css`
-            overflow: visible;
-            -webkit-line-clamp: initial;
-          `}
-        />
-      </Modal.body>
-      <Modal.actions>
-        <Button variant="primary" size="md" onClick={onClose}>
-          확인
-        </Button>
-      </Modal.actions>
+      <div className="modal-content">{children}</div>
     </div>
   );
 };
@@ -66,8 +29,6 @@ Modal.header = ModalHeader;
 Modal.body = ModalBody;
 Modal.actions = ModalActions;
 Modal.divider = ModalDivider;
-
-export default Modal;
 
 const ModalStyle = css`
   position: relative;
@@ -121,3 +82,5 @@ const ModalActionsStyle = css`
   align-items: center;
   justify-content: center;
 `;
+
+export default Modal;

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -11,7 +11,7 @@ const Modal = ({ data, visible, onClose }) => {
     data;
 
   return (
-    <div css={ModalStyle} className={visible && "visible"}>
+    <div css={ModalStyle} className={`${visible && "visible"} modal`}>
       <Modal.header>
         <MessageCardProfile
           sender={sender}

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,0 +1,87 @@
+import { css } from "@emotion/react";
+import Button from "../Button";
+import {
+  MessageCardProfile,
+  MessageCardContent,
+  MessageCardCreatedAt,
+} from "../MessageCard/MessageCard";
+
+const Modal = ({ data, visible, onClose }) => {
+  const { profileImageURL, sender, relationship, content, font, createdAt } =
+    data;
+
+  return (
+    <div css={ModalStyle} className={visible && "visible"}>
+      <Modal.header>
+        <MessageCardProfile
+          sender={sender}
+          profileImageURL={profileImageURL}
+          relationship={relationship}
+          font={font}
+        />
+        <MessageCardCreatedAt createdAt={createdAt} />
+      </Modal.header>
+      <Modal.divider />
+      <Modal.body>
+        <MessageCardContent content={content} />
+      </Modal.body>
+      <Modal.actions>
+        <Button variant="primary" size="md" onClick={onClose}>
+          확인
+        </Button>
+      </Modal.actions>
+    </div>
+  );
+};
+
+const ModalHeader = ({ children }) => {
+  return <div css={ModalHeaderStyle}>{children}</div>;
+};
+
+const ModalBody = ({ children }) => {
+  return <div css={ModalBodyStyle}>{children}</div>;
+};
+
+const ModalActions = ({ children }) => {
+  return <div css={ModalActionsStyle}>{children}</div>;
+};
+
+const ModalDivider = () => {
+  return <hr css={ModalDividerStyle}></hr>;
+};
+
+Modal.header = ModalHeader;
+Modal.body = ModalBody;
+Modal.actions = ModalActions;
+Modal.divider = ModalDivider;
+
+export default Modal;
+
+const ModalStyle = css`
+  position: relative;
+  width: 100%;
+  max-width: calc(100% - 40px);
+  padding: 40px;
+  background-color: var(--white);
+  box-shadow: var(--box-shadow);
+  border-radius: 16px;
+  max-width: calc(100% - 40px);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: 0.3s ease-in-out;
+
+  &.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  @media (min-width: 640px) {
+    width: var(--modal-width);
+    max-width: var(--modal-width);
+  }
+`;
+
+const ModalHeaderStyle = css``;
+const ModalBodyStyle = css``;
+const ModalActionsStyle = css``;
+const ModalDividerStyle = css``;

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -4,7 +4,7 @@ import { BREAKPOINTS } from "../../constants/constants";
 const Modal = ({ children, visible }) => {
   return (
     <div css={ModalStyle} className={`modal ${visible ? "visible" : ""}`}>
-      <div className="modal-content">{children}</div>
+      {children}
     </div>
   );
 };

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -5,6 +5,7 @@ import {
   MessageCardContent,
   MessageCardCreatedAt,
 } from "../MessageCard/MessageCard";
+import { BREAKPOINTS } from "../../constants/constants";
 
 const Modal = ({ data, visible, onClose }) => {
   const { profileImageURL, sender, relationship, content, font, createdAt } =
@@ -19,11 +20,22 @@ const Modal = ({ data, visible, onClose }) => {
           relationship={relationship}
           font={font}
         />
-        <MessageCardCreatedAt createdAt={createdAt} />
+        <MessageCardCreatedAt
+          createdAt={createdAt}
+          customCss={css`
+            font-size: var(--font-size-14);
+          `}
+        />
       </Modal.header>
       <Modal.divider />
       <Modal.body>
-        <MessageCardContent content={content} />
+        <MessageCardContent
+          content={content}
+          customCss={css`
+            overflow: visible;
+            -webkit-line-clamp: initial;
+          `}
+        />
       </Modal.body>
       <Modal.actions>
         <Button variant="primary" size="md" onClick={onClose}>
@@ -61,11 +73,10 @@ const ModalStyle = css`
   position: relative;
   width: 100%;
   max-width: calc(100% - 40px);
-  padding: 40px;
+  padding: 30px 24px;
   background-color: var(--white);
   box-shadow: var(--box-shadow);
   border-radius: 16px;
-  max-width: calc(100% - 40px);
   opacity: 0;
   transform: translateY(20px);
   transition: 0.3s ease-in-out;
@@ -78,10 +89,35 @@ const ModalStyle = css`
   @media (min-width: 640px) {
     width: var(--modal-width);
     max-width: var(--modal-width);
+    padding: 40px;
   }
 `;
 
-const ModalHeaderStyle = css``;
-const ModalBodyStyle = css``;
-const ModalActionsStyle = css``;
-const ModalDividerStyle = css``;
+const ModalHeaderStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ModalDividerStyle = css`
+  height: 1px;
+  margin: 20px 0 4px;
+  background: var(--gray-200);
+  border: 0;
+`;
+
+const ModalBodyStyle = css`
+  height: 180px;
+  margin-bottom: 24px;
+  overflow: auto;
+
+  @media (min-width: ${BREAKPOINTS.md}px) {
+    height: 240px;
+  }
+`;
+
+const ModalActionsStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/components/Modal/ModalContainer.jsx
+++ b/src/components/Modal/ModalContainer.jsx
@@ -1,25 +1,53 @@
 import ReactDOM from "react-dom";
 import { css } from "@emotion/react";
 import Modal from "./Modal";
+import { useEffect, useRef } from "react";
 
 const ModalContainer = ({ modals, visible, hideModal }) => {
   const containerEl = document.getElementById("modal-div");
-  if (!containerEl) return null;
+  const modalRef = useRef(null);
+  const modalNode = modalRef.current;
 
-  if (modals.length === 0) return null;
+  useEffect(() => {
+    if (modals.length === 0) return;
+
+    const handleOutsideClick = (e) => {
+      if (modalNode && !modalNode.contains(e.target)) {
+        hideModal(modals[modals.length - 1].id);
+      }
+    };
+
+    const handleEscKeyDown = (e) => {
+      if (e.key === "Escape") {
+        hideModal(modals[modals.length - 1].id);
+      }
+    };
+
+    document.addEventListener("mousedown", handleOutsideClick);
+    document.addEventListener("keydown", handleEscKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+      document.removeEventListener("keydown", handleEscKeyDown);
+    };
+  }, [modals, modalNode, hideModal]);
+
+  if (!containerEl || modals.length === 0) return null;
 
   return ReactDOM.createPortal(
     <div role="dialog" aria-modal={`${visible}`} css={ModalContainerStyle}>
       <div css={ModalLayerStyle} className={visible && "visible"}></div>
-      {modals?.map((modal) => (
-        <Modal
-          key={modal.id}
-          id={modal.id}
-          data={modal.data}
-          visible={modal.visible}
-          onClose={() => hideModal(modal.id)}
-        />
-      ))}
+      <div ref={modalRef} className="modal-area">
+        {modals?.map((modal) => (
+          <Modal
+            key={modal.id}
+            id={modal.id}
+            data={modal.data}
+            visible={modal.visible}
+            onClose={() => hideModal(modal.id)}
+          />
+        ))}
+      </div>
     </div>,
     containerEl
   );

--- a/src/components/Modal/ModalContainer.jsx
+++ b/src/components/Modal/ModalContainer.jsx
@@ -69,7 +69,7 @@ const ModalContainer = ({ modals, visible, hideModal }) => {
   return ReactDOM.createPortal(
     <div
       role="dialog"
-      aria-modal={`${visible}`}
+      aria-modal={visible}
       tabIndex="-1"
       css={ModalContainerStyle}
     >

--- a/src/components/Modal/ModalContainer.jsx
+++ b/src/components/Modal/ModalContainer.jsx
@@ -1,0 +1,55 @@
+import ReactDOM from "react-dom";
+import { css } from "@emotion/react";
+import Modal from "./Modal";
+
+const ModalContainer = ({ modals, visible, hideModal }) => {
+  const containerEl = document.getElementById("modal-div");
+  if (!containerEl) return null;
+
+  if (modals.length === 0) return null;
+
+  return ReactDOM.createPortal(
+    <div role="dialog" aria-modal={`${visible}`} css={ModalContainerStyle}>
+      <div css={ModalLayerStyle} className={visible && "visible"}></div>
+      {modals?.map((modal) => (
+        <Modal
+          key={modal.id}
+          id={modal.id}
+          data={modal.data}
+          visible={modal.visible}
+          onClose={() => hideModal(modal.id)}
+        />
+      ))}
+    </div>,
+    containerEl
+  );
+};
+
+export default ModalContainer;
+
+const ModalContainerStyle = css`
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ModalLayerStyle = css`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition: 0.3s;
+
+  &.visible {
+    opacity: 1;
+  }
+`;

--- a/src/components/Modal/ModalContainer.jsx
+++ b/src/components/Modal/ModalContainer.jsx
@@ -6,10 +6,11 @@ import { useEffect, useRef } from "react";
 const ModalContainer = ({ modals, visible, hideModal }) => {
   const containerEl = document.getElementById("modal-div");
   const modalRef = useRef(null);
-  const modalNode = modalRef.current;
 
   useEffect(() => {
     if (modals.length === 0) return;
+
+    const modalNode = modalRef.current;
 
     // 모달 외부 클릭: 모달 닫기
     const handleOutsideClick = (e) => {
@@ -18,12 +19,15 @@ const ModalContainer = ({ modals, visible, hideModal }) => {
       }
     };
 
+    // 포커스 트랩 변수 설정
     const focusableElementsSelector =
       'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
 
     const focusableEls = modalRef.current.querySelectorAll(
       focusableElementsSelector
     );
+    if (focusableEls.length === 0) return;
+
     const firstEl = focusableEls[0];
     const lastEl = focusableEls[focusableEls.length - 1];
 
@@ -58,7 +62,7 @@ const ModalContainer = ({ modals, visible, hideModal }) => {
       document.removeEventListener("mousedown", handleOutsideClick);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [modals, modalNode, hideModal]);
+  }, [modals, hideModal]);
 
   if (!containerEl || modals.length === 0) return null;
 

--- a/src/components/Modal/ModalContainer.jsx
+++ b/src/components/Modal/ModalContainer.jsx
@@ -65,6 +65,13 @@ const ModalContainerStyle = css`
   display: flex;
   align-items: center;
   justify-content: center;
+
+  .modal-area {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
 `;
 
 const ModalLayerStyle = css`

--- a/src/components/Modal/ModalContainer.jsx
+++ b/src/components/Modal/ModalContainer.jsx
@@ -71,14 +71,10 @@ const ModalContainer = ({ modals, visible, hideModal }) => {
     >
       <div css={ModalLayerStyle} className={visible && "visible"}></div>
       <div ref={modalRef} className="modal-area">
-        {modals?.map((modal) => (
-          <Modal
-            key={modal.id}
-            id={modal.id}
-            data={modal.data}
-            visible={modal.visible}
-            onClose={() => hideModal(modal.id)}
-          />
+        {modals?.map(({ id, element, visible }) => (
+          <Modal key={id} visible={visible} onClose={() => hideModal(id)}>
+            {element}
+          </Modal>
         ))}
       </div>
     </div>,

--- a/src/components/Modal/ModalContext.jsx
+++ b/src/components/Modal/ModalContext.jsx
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const ModalContext = createContext(undefined);
+
+export default ModalContext;

--- a/src/components/Modal/ModalProvider.jsx
+++ b/src/components/Modal/ModalProvider.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ModalContext from "./ModalContext";
 import ModalContainer from "../Modal/ModalContainer";
 
@@ -37,6 +37,18 @@ const ModalProvider = ({ children }) => {
       setModals((prev) => prev.filter((modal) => modal.id !== id));
     }, MODAL_VISIBLE_MS + MODAL_DELETE_DOM_MS);
   };
+
+  useEffect(() => {
+    if (modals.some((modal) => modal.visible)) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [modals]);
 
   return (
     <ModalContext.Provider value={{ modals, showModal, hideModal }}>

--- a/src/components/Modal/ModalProvider.jsx
+++ b/src/components/Modal/ModalProvider.jsx
@@ -16,9 +16,9 @@ const ModalProvider = ({ children }) => {
     );
   };
 
-  const showModal = (modal) => {
+  const showModal = (modalElement) => {
     const id = nanoid();
-    const newModal = { ...modal, id, visible: false }; // visible 기본값 false: 등장 애니메이션 준비
+    const newModal = { id, visible: false, element: modalElement }; // visible 기본값 false: 등장 애니메이션 준비
 
     // Step 1: 모달 추가
     setModals((prev) => [...prev, newModal]);

--- a/src/components/Modal/ModalProvider.jsx
+++ b/src/components/Modal/ModalProvider.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { nanoid } from "nanoid";
 import ModalContext from "./ModalContext";
 import ModalContainer from "../Modal/ModalContainer";
 
@@ -16,7 +17,7 @@ const ModalProvider = ({ children }) => {
   };
 
   const showModal = (modal) => {
-    const id = Math.random().toString(36).substr(2, 9);
+    const id = nanoid();
     const newModal = { ...modal, id, visible: false }; // visible 기본값 false: 등장 애니메이션 준비
 
     // Step 1: 모달 추가

--- a/src/components/Modal/ModalProvider.jsx
+++ b/src/components/Modal/ModalProvider.jsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import ModalContext from "./ModalContext";
+import ModalContainer from "../Modal/ModalContainer";
+
+const MODAL_VISIBLE_MS = 300;
+const MODAL_DELETE_DOM_MS = 300;
+const MODAL_ANIM_READY_MS = 10;
+
+const ModalProvider = ({ children }) => {
+  const [modals, setModals] = useState([]);
+
+  const setModalsVisibleFn = ({ id, visible }) => {
+    return setModals((prev) =>
+      prev.map((modal) => (modal.id === id ? { ...modal, visible } : modal))
+    );
+  };
+
+  const showModal = (modal) => {
+    const id = Math.random().toString(36).substr(2, 9);
+    const newModal = { ...modal, id, visible: false }; // visible 기본값 false: 등장 애니메이션 준비
+
+    // Step 1: 모달 추가
+    setModals((prev) => [...prev, newModal]);
+
+    // Step 2: visible 상태만 true로 업데이트 → 등장 애니메이션 트리거
+    setTimeout(() => {
+      setModalsVisibleFn({ id, visible: true });
+    }, MODAL_ANIM_READY_MS);
+  };
+
+  const hideModal = (id) => {
+    // Step 1: visible 상태만 false로 업데이트 → 퇴장 애니메이션 트리거
+    setModalsVisibleFn({ id, visible: false });
+
+    // Step 2: 애니메이션 끝나고 DOM에서 제거
+    setTimeout(() => {
+      setModals((prev) => prev.filter((modal) => modal.id !== id));
+    }, MODAL_VISIBLE_MS + MODAL_DELETE_DOM_MS);
+  };
+
+  return (
+    <ModalContext.Provider value={{ modals, showModal, hideModal }}>
+      {children}
+      <ModalContainer
+        modals={modals}
+        hideModal={hideModal}
+        visible={modals.some((modal) => modal.visible)}
+      />
+    </ModalContext.Provider>
+  );
+};
+
+export default ModalProvider;

--- a/src/components/Modal/useModal.js
+++ b/src/components/Modal/useModal.js
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import ModalContext from "./ModalContext";
+
+const useModal = () => {
+  const context = useContext(ModalContext);
+  if (!context)
+    throw new Error("useModal은 ModalProvider 안에서만 호출되어야 합니다.");
+  return context;
+};
+
+export default useModal;

--- a/src/components/Toast/Toast.jsx
+++ b/src/components/Toast/Toast.jsx
@@ -4,7 +4,7 @@ import IconClose from "../../assets/images/ic-close-gray.svg";
 
 const Toast = ({ id, state = "success", message, visible, onClose }) => {
   return (
-    <li css={ToastStyle} className={visible ? "visible" : ""}>
+    <li css={ToastStyle} className={visible && "visible"}>
       <div className="toast-content">
         {state === "success" && (
           <img src={IconSuccess} alt="처리 완료" className="status-icon" />

--- a/src/components/Toast/ToastProvider.jsx
+++ b/src/components/Toast/ToastProvider.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { nanoid } from "nanoid";
 import ToastContext from "./ToastContext";
 import ToastContainer from "./ToastConatiner";
 
@@ -21,7 +22,7 @@ const ToastProvider = ({ children }) => {
 
   const showToast = ({ message }) => {
     // message만 파라미터로 받고, id는 여기서 직접 생성 (삭제할 토스트 구분용 임의 id)
-    const id = Math.random().toString(36).substr(2, 9); // 🎯 id 생성 방식 개선 예정(nanoid)
+    const id = nanoid();
     const newToast = { id, message, visible: false };
 
     // Step 1: visible: false로 토스트 등장 애니메이션 준비

--- a/src/components/Toast/ToastProvider.jsx
+++ b/src/components/Toast/ToastProvider.jsx
@@ -21,13 +21,11 @@ const ToastProvider = ({ children }) => {
 
   const showToast = ({ message }) => {
     // message만 파라미터로 받고, id는 여기서 직접 생성 (삭제할 토스트 구분용 임의 id)
-    const id = Math.random().toString(36).substr(2, 9);
+    const id = Math.random().toString(36).substr(2, 9); // 🎯 id 생성 방식 개선 예정(nanoid)
+    const newToast = { id, message, visible: false };
 
-    /*
-     * 토스트 show/hide 애니메이션 🌌
-     */
     // Step 1: visible: false로 토스트 등장 애니메이션 준비
-    setToasts((prev) => [...prev, { id, message, visible: false }]); // visible: 애니메이션 제어용
+    setToasts((prev) => [...prev, newToast]); // visible: 애니메이션 제어용
 
     // Step 2: visible: true로 변경 → 등장 애니메이션 시작
     setTimeout(() => {
@@ -59,6 +57,11 @@ const ToastProvider = ({ children }) => {
     <ToastContext.Provider value={{ toasts, showToast, hideToast }}>
       {children}
       <ToastContainer toasts={toasts} hideToast={hideToast} />
+      <ModalContainer
+        modals={modals}
+        hideModal={hideModal}
+        visible={modals.visible}
+      />
     </ToastContext.Provider>
   );
 };

--- a/src/components/Toast/useToast.js
+++ b/src/components/Toast/useToast.js
@@ -1,9 +1,11 @@
 import { useContext } from "react";
 import ToastContext from "./ToastContext";
 
-export const useToast = () => {
+const useToast = () => {
   const context = useContext(ToastContext);
   if (!context)
     throw new Error("useToast는 ToastProvider 안에서만 호출되어야 합니다.");
   return context;
 };
+
+export default useToast;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,15 +5,18 @@ import { Reset } from "./styles/Reset.jsx";
 import { Variables } from "./styles/Variables.jsx";
 import { BrowserRouter } from "react-router-dom";
 import ToastProvider from "./components/Toast/ToastProvider.jsx";
+import ModalProvider from "./components/Modal/ModalProvider.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <ToastProvider>
-      <Reset />
-      <Variables />
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </ToastProvider>
+    <ModalProvider>
+      <ToastProvider>
+        <Reset />
+        <Variables />
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ToastProvider>
+    </ModalProvider>
   </StrictMode>
 );

--- a/src/pages/StyleGuide/StyleGuidePage.jsx
+++ b/src/pages/StyleGuide/StyleGuidePage.jsx
@@ -30,7 +30,8 @@ const mockMessages = [
     profileImageURL:
       "https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8",
     relationship: "가족",
-    content: "열심히 일하는 모습 멋있습니다.",
+    content:
+      "열심히 일하는 모습 멋있습니다. 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!",
     font: "Pretendard",
     createdAt: "2023-11-01T08:05:25.399056Z",
   },

--- a/src/pages/StyleGuide/StyleGuidePage.jsx
+++ b/src/pages/StyleGuide/StyleGuidePage.jsx
@@ -297,6 +297,14 @@ const StyleGuidePage = () => {
           토스트 열기
         </Button>
       </section>
+      <section css={sectionStyle}>
+        <h2>Modal</h2>
+        <MessageCardList
+          messages={mockMessages}
+          editMode={false}
+          openMessageCardModal={(data) => showModal({ data })}
+        />
+      </section>
     </div>
   );
 };

--- a/src/pages/StyleGuide/StyleGuidePage.jsx
+++ b/src/pages/StyleGuide/StyleGuidePage.jsx
@@ -10,7 +10,8 @@ import MessageCard from "../../components/MessageCard/MessageCard";
 import AddMessageCardButton from "../../components/MessageCard/AddMessageCardButton";
 import MessageCardList from "../../components/MessageCard/MessageCardList";
 import MessageCardListStyle from "../../components/MessageCard/MessageCardListStyle";
-import { useToast } from "../../components/Toast/useToast";
+import useToast from "../../components/Toast/useToast";
+import useModal from "../../components/Modal/useModal";
 
 const mockMessage = {
   sender: "강미나",
@@ -92,6 +93,7 @@ const mockMessages = [
 
 const StyleGuidePage = () => {
   const { showToast } = useToast();
+  const { showModal } = useModal();
 
   return (
     <div css={pageStyle}>

--- a/src/pages/StyleGuide/StyleGuidePage.jsx
+++ b/src/pages/StyleGuide/StyleGuidePage.jsx
@@ -12,6 +12,7 @@ import MessageCardList from "../../components/MessageCard/MessageCardList";
 import MessageCardListStyle from "../../components/MessageCard/MessageCardListStyle";
 import useToast from "../../components/Toast/useToast";
 import useModal from "../../components/Modal/useModal";
+import MessageCardModal from "../../components/Modal/MessageCardModal";
 
 const mockMessage = {
   sender: "강미나",
@@ -300,10 +301,18 @@ const StyleGuidePage = () => {
       </section>
       <section css={sectionStyle}>
         <h2>Modal</h2>
+        <Button
+          variant="outlined"
+          onClick={() => showModal(<MessageCardModal data={mockMessage} />)}
+        >
+          모달 열기
+        </Button>
         <MessageCardList
           messages={mockMessages}
           editMode={false}
-          openMessageCardModal={(data) => showModal({ data })}
+          openMessageCardModal={(data) =>
+            showModal(<MessageCardModal data={data} />)
+          }
         />
       </section>
     </div>


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Modal 컴포넌트 사용법
1. `useModal` 훅 import 
    - `import useModal from "../../components/Modal/useModal";`
2. 컴포넌트 안에서 `showModal` 불러오기
    - `const { showModal } = useModal();`
3. `showModal`로 원하는 모달 컴포넌트 호출 (2가지 방법)
  - showModal() 안에 컴포넌트를 넣고, 데이터를 컴포넌트의 prop으로 넘겨줍니다.
  - `showModal( <컴포넌트 데이터프롭={데이터} /> );`
  3-1. `onClick`으로 호출
    ```
    <Button
        variant="outlined"
        onClick={() => showModal(<MessageCardModal data={mockMessage} />)}
      >
      모달 열기
    </Button>
    ```

    3-2. `MessageCardList`에서 각 `MessageCard` 클릭 시 호출
     ```
    <MessageCardList
        messages={mockMessages}
        editMode={false}
        openMessageCardModal={(data) =>
          showModal(<MessageCardModal data={data} />)
        }
      />```

- 포커스 트랩, esc키 입력 시 모달 닫기, 모달 show/hide 애니메이션을 구현했습니다.
- `showModal()`에 아무 컴포넌트도 전달하지 않으면 이렇게 모달 영역만 나타납니다. (컴포넌트 전달해주세요!)
![modal-empty](https://github.com/user-attachments/assets/88ac68a7-d368-44c9-a42f-e4e3eae85403)


## 💬 공유사항 to 리뷰어

- 모달을 만들고 보니 공통 컴포넌트 형태가 아니라 MessageCard에 맞춰진 형태라서, 하나의 Modal을 Modal과 MessageCardModal로 구조 분리했습니다.
- Toast, StyleGuidePage는 일부 문법 간결화 및 테스트 코드 추가이므로 리뷰 생략하셔도 될 것 같습니다.
- Modal 하단에 합성 컴포넌트들이 선언되어 있는데... 구조 변경하면서 삭제하는걸 깜빡했습니다 무시해주세요..!😅
- 전체적으로 구조를 변경하는 과정에서 라인 변경이 많이 일어났습니다... 이 PR을 다시 2개로 나눠보니 라인 변경수가 400개 / 200개로 나뉘던데, 추후 비슷한 일이 발생할 때 차라리 PR이 3개가 되더라도 더 작게 쪼개는 게 더 나으실까요??

## 📸스크린샷 (선택)
### 버튼 클릭 시 모달 오픈

https://github.com/user-attachments/assets/a8f10e61-5b4c-4f9d-9cfe-f062cac62a26

### 메시지카드 클릭 시 모달 오픈

https://github.com/user-attachments/assets/6427b364-1f12-4c9c-9d8c-c50896db1b8c




## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
