### PR TITLE
HotFix: 공유 항목 클릭 시 드롭다운 관련 콘솔 경고 뜨는 현상 수정

### DIFF
--- a/src/components/Toast/ToastProvider.jsx
+++ b/src/components/Toast/ToastProvider.jsx
@@ -21,7 +21,6 @@ const ToastProvider = ({ children }) => {
   };
 
   const showToast = ({ message, state = "success" }) => {
-    console.log(state);
     // message만 파라미터로 받고, id는 여기서 직접 생성 (삭제할 토스트 구분용 임의 id)
     const id = nanoid();
     const newToast = { id, message, visible: false, state };

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -9,12 +9,12 @@ export const TEAM = "7";
 export const SHARE_DROPDOWN_ITEMS = [
   {
     label: "카카오톡 공유",
-    successMsg: "롤링페이퍼를 카카오톡으로 공유합니다.",
+    value: "롤링페이퍼를 카카오톡으로 공유합니다.",
     errorMsg: "카카오톡 공유에 실패했어요..🥲",
   },
   {
     label: "URL 복사",
-    successMsg: "URL이 복사되었습니다.",
+    value: "URL이 복사되었습니다.",
     errorMsg: "URL 복사에 실패했어요..🥲",
   },
 ];

--- a/src/pages/List/ListPageHeader.jsx
+++ b/src/pages/List/ListPageHeader.jsx
@@ -45,7 +45,7 @@ const ListPageHeader = ({ recipient }) => {
 
       // 클립보드에 URL 복사 - 성공
       navigator.clipboard.writeText(currentUrl);
-      showToast({ message: option.successMsg });
+      showToast({ message: option.value });
     }
 
     if (option.label === "카카오톡 공유") {


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `/list`페이지에서 공유 성공 시 `constants.js`에 있는 `SHARE_DROPDOWN_ITEMS` 상수의 `successMsg`가 전달되도록 수정했으나, 드롭다운에서는 option.`value`를 받게 되어있어 드롭다운 형식에 맞게 `successMsg` ➡️ 다시 `value`로 프로퍼티명 변경
- Toast 에러 UI 추가 과정에서 생긴 이슈로 추정

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 에러 수정이라서 셀프 머지하겠습니다!

## 📸스크린샷 (선택)
![스크린샷 2025-06-06 오후 2 34 42](https://github.com/user-attachments/assets/be7a9d7b-b5d4-4578-ad72-fe8017fc7f1c)
- 드롭다운에 `option.value`가 전달되지 않아서 경고 발생

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
