### PR TITLE
[1차 QA 반영] Fix: Dropdown, Toast UI 수정

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -12,6 +12,7 @@ const DropdownSelect = ({
   options = [], //[{label:..., value:..., onClick:...},{...}]
   customButton, // 버튼 커스텀?
   dropdownWidth = "140px", //trigger를 사용한 dropdown의 너비, 기본값인 140px은 ShereButton 일 때
+  isFontDropdown = false,
 }) => {
   const [internalValue, setInternalValue] = useState(
     () => (options?.length > 0 ? options[0] : null) //오류방지
@@ -86,6 +87,7 @@ const DropdownSelect = ({
               key={option.value}
               onClick={() => handleSelect(option)}
               css={dropdownOption}
+              style={isFontDropdown ? { fontFamily: option.value } : {}}
             >
               {option.label}
             </li>
@@ -103,10 +105,11 @@ export default DropdownSelect;
 const dropdownSelectWrapper = css`
   position: relative;
   display: inline-block;
+  max-width: 320px;
 `;
 
 const selectedTrigger = css`
-  width: 320px;
+  width: 100%;
   height: 50px;
   padding: 12px 16px;
   font-size: var(--font-size-16);

--- a/src/components/Toast/ToastContainer.jsx
+++ b/src/components/Toast/ToastContainer.jsx
@@ -6,7 +6,7 @@ const ToastContainer = ({ toasts, hideToast }) => {
   const containerEl = document.getElementById("toast-div");
   if (!containerEl) return null;
 
-  if (toasts.length === 0) return null; // 토스트 없을 때 빈 ul 태그 렌더링 방지
+  if (toasts.length === 0) return null; // 토스트 없을 때 빈 ol 태그 렌더링 방지
 
   return ReactDOM.createPortal(
     <ol css={ToastContainerStyle}>
@@ -33,10 +33,14 @@ const ToastContainerStyle = css`
   bottom: 70px;
   left: 50%;
   transform: translateX(-50%);
-  width: 100%;
-  max-width: 524px;
+  width: calc(100% - 40px);
   height: 64px;
   display: flex;
   flex-direction: column-reverse; // 토스트 역순으로 쌓기
   gap: 12px;
+
+  @media (min-width: 540px) {
+    width: 100%;
+    max-width: 524px;
+  }
 `;


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- [x] 폰트 선택 드롭다운에서 해당 폰트 미리보기 표시
- [x] 드롭다운 width 조정
- [x] 토스트 모바일 반응형: 좌우 여백 추가

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 드롭다운 width를 원래 만재님이 수정하시기로 하셨는데, 폰트 선택 드롭다운 항목에서 폰트를 미리 확인할 수 있도록 드롭다운을 수정하다보니 width값도 같이 수정하게 되었습니다. 확인 한번 해주시고, 잘못된 부분이 있다면 알려주세요!

## 📸스크린샷 (선택)
### 드롭다운 폰트 미리보기 적용 + width 조정
![제목 없음](https://github.com/user-attachments/assets/b580c57c-3fd3-4748-9e1c-6402bda0c3a0)
### 토스트 모바일 좌우 여백 추가
![제목 없음2](https://github.com/user-attachments/assets/f3aca201-812d-4e88-9552-143b7bfa9849)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
