### PR TITLE
[1차 QA 반영] fix(Slider): 카드 링크 추가·스크롤 스냅 도입·슬라이드 초기화·페이지네이션 오류 해결

### DIFF
--- a/src/pages/List/ListPage.jsx
+++ b/src/pages/List/ListPage.jsx
@@ -1,10 +1,11 @@
 import { Link } from "react-router-dom";
+import { css } from "@emotion/react";
 import Button from "../../components/Button/Button";
 import GlobalHeader from "../../components/Header/GlobalHeader";
 import Slider from "./Slider";
-import { css } from "@emotion/react";
 import { BREAKPOINTS } from "../../constants/constants";
 
+//  슬라이더에 들어갈 목업 아이템
 export const mockItems = [
   { id: 1, title: "Card 1" },
   { id: 2, title: "Card 2" },
@@ -18,48 +19,37 @@ export const mockItems = [
   { id: 10, title: "Card 10" },
 ];
 
+//  리스트 페이지 컴포넌트
 function ListPage() {
   return (
     <div>
+      {/* 상단 글로벌 헤더 + CTA 버튼 */}
       <GlobalHeader>
         <Button
           as={Link}
           to="/post"
           variant="outlined"
           size="md"
-          css={css`
-            width: auto;
-            @media (max-width: ${BREAKPOINTS.md}px) {
-              font-size: var(--font-size-14);
-            }
-          `}
+          css={headerButtonStyle}
         >
           롤링 페이퍼 만들기
         </Button>
       </GlobalHeader>
-      <main css={pageWrapper}>
+      {/* 메인 콘텐츠 영역 */}
+      <main css={pageWrapper} role="main">
+        {/* 슬라이더 섹션 */}
         <section css={section}>
-          <div css={paper}>
-            <h2 css={title}>인기 롤링 페이퍼 🔥</h2>
-            <Slider items={mockItems} />
-          </div>
-          <div css={paper}>
-            <h2 css={title}>최근에 만든 롤링 페이퍼⭐️</h2>
-            <Slider items={mockItems} />
-          </div>
+          <SliderSection title="인기 롤링 페이퍼 🔥" items={mockItems} />
+          <SliderSection title="최근에 만든 롤링 페이퍼⭐️" items={mockItems} />
         </section>
-        <div css={padding}>
+        {/* 하단 CTA 버튼 */}
+        <div css={ctaWrapper}>
           <Button
             as={Link}
             to="/post"
             variant="primary"
             size="lg"
-            css={css`
-              width: 100%;
-              @media (min-width: ${BREAKPOINTS.lg}px) {
-                max-width: 280px;
-              }
-            `}
+            css={ctaButtonStyle}
           >
             나도 만들어보기
           </Button>
@@ -67,8 +57,21 @@ function ListPage() {
       </main>
     </div>
   );
+
+  function SliderSection({ title, items }) {
+    return (
+      <div css={sliderBlock}>
+        <h2 css={sliderTitle}>{title}</h2>
+        <Slider items={items} />
+      </div>
+    );
+  }
 }
+
 export default ListPage;
+
+//  스타일 정의  //
+//  스타일 정의  //
 
 const pageWrapper = css`
   display: flex;
@@ -81,11 +84,10 @@ const pageWrapper = css`
   gap: 48px;
 
   @media (min-width: ${BREAKPOINTS.md}px) {
-    height: 951px;
+    min-height: 951px;
   }
   @media (min-width: ${BREAKPOINTS.lg}px) {
     max-width: 1160px;
-    height: auto;
     gap: 72px;
   }
 `;
@@ -97,7 +99,7 @@ const section = css`
   gap: 72px;
 `;
 
-const paper = css`
+const sliderBlock = css`
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -107,18 +109,34 @@ const paper = css`
   }
 `;
 
-const title = css`
+const sliderTitle = css`
   font-size: var(--font-size-20);
   font-weight: 600;
   text-align: left;
   padding-left: 20px;
+
   @media (min-width: ${BREAKPOINTS.md}px) {
     font-size: var(--font-size-24);
     font-weight: var(--font-weight-bold);
   }
 `;
 
-const padding = css`
+//버튼 style
+const headerButtonStyle = css`
+  width: auto;
+  @media (max-width: ${BREAKPOINTS.md}px) {
+    font-size: var(--font-size-14);
+  }
+`;
+
+const ctaButtonStyle = css`
+  width: 100%;
+  @media (min-width: ${BREAKPOINTS.lg}px) {
+    max-width: 280px;
+  }
+`;
+
+const ctaWrapper = css`
   width: var(--content-width);
   padding: var(--content-padding);
   display: flex;

--- a/src/pages/List/ListPage.jsx
+++ b/src/pages/List/ListPage.jsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { css } from "@emotion/react";
+
 import Button from "../../components/Button/Button";
 import GlobalHeader from "../../components/Header/GlobalHeader";
 import Slider from "./Slider";

--- a/src/pages/List/Slider.jsx
+++ b/src/pages/List/Slider.jsx
@@ -33,7 +33,7 @@ const Slider = ({ items }) => {
   const breakpoint = useBreakpoint();
   const { cardWidth, visibleCount } = SETTINGS[breakpoint] || SETTINGS.desktop;
 
-  // 슬라이드 범위 계산산
+  // 슬라이드 범위 계산
   const TOTAL_COUNT = items.length;
   const maxIndex = Math.max(0, Math.ceil(TOTAL_COUNT - visibleCount));
   const gap = SLIDER_GAP;
@@ -44,7 +44,7 @@ const Slider = ({ items }) => {
   const [slideIndex, setSlideIndex] = useState(0);
   const wrapperRef = useRef(null); // 스크롤 컨테이너 참조
 
-  // 뷰포트 변경 시 인덱스, 스크롤 초기화화
+  // 뷰포트 변경 시 인덱스, 스크롤 초기화
   useEffect(() => {
     setSlideIndex(0);
     if (wrapperRef.current) {
@@ -77,7 +77,7 @@ const Slider = ({ items }) => {
 
   return (
     <div css={sliderOuter}>
-      {/* 데스크탑 모드에서만 Pagination 표시시*/}
+      {/* 데스크탑 모드에서만 Pagination 표시*/}
       {showPagination && (
         <Pagination
           slideIndex={slideIndex}
@@ -104,7 +104,7 @@ const Slider = ({ items }) => {
 export default Slider;
 
 // CSS 스타일 정의
-// 전체 컨테이너: 중앙 정렬 + 최대 너비비
+// 전체 컨테이너: 중앙 정렬 + 최대 너비
 const sliderOuter = css`
   width: 100%;
   max-width: ${SLIDER_MAX_WIDTH}px;
@@ -112,7 +112,7 @@ const sliderOuter = css`
   position: relative;
 `;
 
-// 래퍼: 가로 스크롤 + 스냅 + 스크롤바 숨김김
+// 래퍼: 가로 스크롤 + 스냅 + 스크롤바 숨김
 const sliderWrapper = css`
   width: 100%;
   border: 1px solid #666;

--- a/src/pages/List/Slider.jsx
+++ b/src/pages/List/Slider.jsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import useBreakpoint from "./hooks/useResponsive";
 import Pagination from "./Pagination";
 import {
@@ -38,6 +39,7 @@ const Slider = ({ items }) => {
   const gap = SLIDER_GAP;
   const isDesktop = breakpoint === "desktop";
 
+  const showPagination = isDesktop && items.length > visibleCount;
   // 슬라이드 인덱스 상태
   const [slideIndex, setSlideIndex] = useState(0);
 
@@ -61,13 +63,14 @@ const Slider = ({ items }) => {
   const transformStyle = isDesktop
     ? {
         transform: `translateX(-${(cardWidth + gap) * slideIndex}px)`,
+        transition: "transform 0.3s ease",
       }
     : {};
 
   return (
     <div css={sliderOuter}>
       {/* 데스크탑 모드에서만 Pagination 버튼 렌더링 */}
-      {isDesktop && (
+      {showPagination && (
         <Pagination
           slideIndex={slideIndex}
           maxIndex={maxIndex}
@@ -79,12 +82,12 @@ const Slider = ({ items }) => {
       {/* 슬라이드 영역:
           - 데스크탑: overflow: hidden
           - 태블릿/모바일: 가로 스크롤 */}
-      <div css={[wrapper, isDesktop ? sliderWrapper : scrollWrapper]}>
+      <div css={sliderWrapper}>
         <div css={sliderTrack} style={transformStyle}>
-          {items.map((item, id) => (
-            <div key={id} css={card}>
+          {items.map((item) => (
+            <Link key={item.id} to={`/post/${item.id}`} css={card}>
               {item.title}
-            </div>
+            </Link>
           ))}
         </div>
       </div>
@@ -98,24 +101,16 @@ export default Slider;
 // 전체 슬라이더 컨테이너 (버튼 기준 position: relative)
 const sliderOuter = css`
   width: 100%;
-  max-width: ${SLIDER_MAX_WIDTH}px; // 데스크탑 기준 최대 너비
+  max-width: ${SLIDER_MAX_WIDTH}px; /* 데스크탑 기준 최대 너비 */
   margin: 0 auto;
   position: relative;
 `;
 
 // 공통 wrapper: border만 있고, overflow는 하위 스타일에서 분기
-const wrapper = css`
+const sliderWrapper = css`
   width: 100%;
   border: 1px solid #666;
-`;
 
-// 데스크탑: 슬라이드 트랙이 넘어가지 않도록 overflow 숨김
-const sliderWrapper = css`
-  overflow: hidden;
-`;
-
-// 태블릿/모바일: 가로 스크롤 사용, 세로 스크롤 제거
-const scrollWrapper = css`
   overflow-x: auto;
   overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
@@ -132,7 +127,6 @@ const scrollWrapper = css`
 const sliderTrack = css`
   display: flex;
   gap: ${SLIDER_GAP}px;
-  transition: transform 0.3s ease;
 `;
 
 // 카드 스타일 (기본: 모바일, 미디어쿼리: 데스크탑)


### PR DESCRIPTION
## 📝 요약(Summary)

**1. 슬라이드 카드에 link 넣기 (Slider.jsx)**
- 기존에 `div`로 생성되던 카드들을 `Link` 컴포넌트로 대체  
- 카드 안 콘텐츠는 API 연동 후 변경 예정

**2. 카드 개수 3개 이하일 때 양쪽 슬라이더 버튼 제거 (Slider.jsx)**
- `showPagination = items.length > visibleCount` 조건으로 버튼 렌딩 제어

**3. 뷰포트 변경 시 슬라이드 꼬임 해결**
- `useEffect([breakpoint])`에서 `slideIndex`와 `wrapperRef.current.scrollLeft`를 `0`으로 리셋  
  - 데스크탑↔태블릿↔모바일 전환 시 이전 스크롤 상태 유지 문제 해결

**4. PC 터치스크린도 동일한 스크롤 방식 적용**
- 기존 `transform/translate` 로직 삭제  
- CSS `scroll-snap` + `overflow-x: auto` 방식으로 전면 수정  
   - 기존 transform/translate 방식은 데스크탑 터치스크린 제어에 부적합
   - 반응형 전 구간 하나의 스크롤 기반 방식을 쓰면 유지보수 및 컨트롤이 쉬움
   - 데스크탑에서만 슬라이드 시 카드 위치가 맞춰지도록 설정을 했습니다 (시안 참고)  
   - 이 방식을 많이 쓰는지는.. 잘 모르겠습니다.. 처음 접하는 방식이었어요

---

## 💬 공유사항 to 리뷰어

처음 접하는 개념이 많아 간단히 정리했습니다!

- **scroll-snap-type: x proximity / mandatory**  
  스크롤 축과 스냅 적용 방식을 지정

- **scroll-snap-align: start / center / end**  
  자식 요소의 스냅 위치(start/center/end) 설정

- **scroll-snap-stop: normal / always**  
  스크롤 속도가 빨라도 스냅 포인트 준수 여부

- **ref.current.scrollLeft**  
  현재 가로 스크롤 위치(px) 조회

- **element.scrollBy({ left, behavior })**  
  부드럽게 스크롤 이동하게 하는 메서드 (transform 대체로 사용했습니)

- **onScroll 이벤트**  
  스크롤 시 호출되는 콜백

**터치 스크롤 흐름**  
1. `onScroll` 이벤트 → CSS 스크롤 스냅으로 슬라이드 이동  
2. 핸들러에서 `ref.current.scrollLeft` 확인 → `slideIndex` 동기화  
3. `slideIndex`로 페이지네이션 상태 관리  

**페이지네이션 버튼 클릭 흐름**  
1. `wrapperRef.scrollBy(...)` 호출 → 스크롤 이동  
2. `onScroll` 이벤트 발생 → `slideIndex` 동기화  

> [Scroll snap 참고 블로그](https://inpa.tistory.com/entry/CSS-%F0%9F%93%9A-%EC%B5%9C%EC%8B%A0-CSS-%EA%B8%B0%EB%8A%A5-%F0%9F%8E%A8-CSS-Scroll-snap#scroll-snap-type)  
> [scrollBy MDN](https://developer.mozilla.org/ko/docs/Web/API/Window/scrollBy)  
> [Scroll snap 한계](https://solo5star.dev/posts/57/)  

---

## 🚩 리뷰 포인트

1. **ListPage 하단 여백**  
   margin/padding을 줘도 적용이 안 되던데... 어느 부분을 놓친 건지 조언 부탁드립니다.

2. **성능**
   성능 쪽에서 부족한 부분이 있는지 확인 부탁드립니다   
   e.g. onScroll 이벤트

4. **페이지네이션 방식**  
   한 번에 한 페이지씩 이동하는 방식과 현재 방식 중 어떤 게 나을까요?
   사실 페이지씩 이동하면 구현하기가 어려울 것 같긴합니다..

5. **카드와 페이지네이션 간격**  
   카드가 Link라서 그런지 버튼을 누르다가 카드가 눌리는 경우가 많았는데 사이에 여백을 좀 넣을까요? 

---

## 📸스크린샷 (선택)
### 모바일
![모바일2](https://github.com/user-attachments/assets/0dffc0de-ea72-48a9-8d4e-12ac55d3eda1)

### 태블릿
![타블렛2](https://github.com/user-attachments/assets/ae9fc633-1219-44e5-b06c-2cfcdf9f70aa)

### 데스크탑
![데스크탑2](https://github.com/user-attachments/assets/313accb2-d7d0-47c0-a0ef-0a87468832f8)

### 카드 4개 이하에서 페이지네이션 숨김
![페이지네이션 숨김](https://github.com/user-attachments/assets/93b10770-ceff-4495-bffd-b4aa78dbb323)

---

## 수정 예정
+ 모바일/태블릿에서 데스크탑으로 직접 변경 시 페이지네이션이 보이지 않는 오류 
+ ListPage 하단 여백
+ api 연동

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
