### PR TITLE
refactor: UX 개선을 위해 뷰포트 변경 시 카드 순서 초기화 로직 삭제

### DIFF
--- a/src/pages/List/Slider.jsx
+++ b/src/pages/List/Slider.jsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
 import { Link } from "react-router-dom";
 import useBreakpoint from "./hooks/useResponsive";
 import Pagination from "./Pagination";
@@ -43,14 +43,6 @@ const Slider = ({ items }) => {
   // 상태 및 레퍼런스
   const [slideIndex, setSlideIndex] = useState(0);
   const wrapperRef = useRef(null); // 스크롤 컨테이너 참조
-
-  // 뷰포트 변경 시 인덱스, 스크롤 초기화
-  useEffect(() => {
-    setSlideIndex(0);
-    if (wrapperRef.current) {
-      wrapperRef.current.scrollLeft = 0;
-    }
-  }, [breakpoint]);
 
   // 스크롤 이벤트 (slideIndex 동기화)
   const handleScroll = () => {


### PR DESCRIPTION
## 📝 요약(Summary)
데스크탑에서 4개씩 정렬하기 위해 뷰포트 바뀔 때마다 인덱스·스크롤 초기화하는 아래 코드를 삭제했습니다.
```js
  // 뷰포트 변경 시 인덱스, 스크롤 초기화
  useEffect(() => {
    setSlideIndex(0);
    if (wrapperRef.current) {
      wrapperRef.current.scrollLeft = 0;
    }
  }, [breakpoint]);
```

변경 이유
+ CSS scroll-snap이 리사이즈 시 가장 가까운 카드로 자동 스냅
+ 별도 초기화 없이도 UI 꼬임 없이 정렬 보장

삭제 후 고려 사항
+ 리사이즈 전 중간 카드(2~3번째) 위치 유지 → 약간 덜컥거릴 수 있음
+ slideIndex 상태와 실제 스크롤 위치가 잠깐 어긋날 가능성

결론
+ UX 관점에서 “보던 카드를 이어 보는 것”이 더 중요하다고 판단
+ 초기화 로직 삭제하고 scroll-snap에만 맡기기로 결정

## 💬 공유사항 to 리뷰어

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
