### PR TITLE
Feature: 롤링페이퍼 생성 페이지(PostCreatePage) api post 구현

### DIFF
--- a/src/api/post/createRecipient.js
+++ b/src/api/post/createRecipient.js
@@ -1,0 +1,20 @@
+const createRecipient = async (data) => {
+  const url = `https://rolling-api.vercel.app/16-7/recipients/`;
+  console.log(data);
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    throw new Error("롤링페이퍼 생성에 실패했어요. 😥");
+  }
+
+  const resData = await res.json();
+
+  return resData;
+};
+
+export default createRecipient;

--- a/src/api/post/createRecipient.js
+++ b/src/api/post/createRecipient.js
@@ -1,6 +1,5 @@
 const createRecipient = async (data) => {
   const url = `https://rolling-api.vercel.app/16-7/recipients/`;
-  console.log(data);
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/pages/Post/PostCreate/PostCreatePage.jsx
+++ b/src/pages/Post/PostCreate/PostCreatePage.jsx
@@ -1,12 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import Label from "../../components/Form/Label";
-import Input from "../../components/Form/Input";
-import ToInput from "./components/ToInPut";
-import SelectBackground from "./components/SeletBackground";
-import GlobalHeader from "../../components/Header/GlobalHeader";
-import Button from "../../components/Button";
 import styled from "@emotion/styled";
+import Label from "../../../components/Form/Label";
+import Input from "../../../components/Form/Input";
+import SelectBackground from "../components/SelectBackground";
+import GlobalHeader from "../../../components/Header/GlobalHeader";
+import Button from "../../../components/Button";
+import createRecipient from "../../../api/post/createRecipient";
 
 const Container = styled.div`
   max-width: 600px;
@@ -28,7 +28,7 @@ const HeaderWrapper = styled.div`
 const MAX_TO_LENGTH = 20;
 
 const PostCreatePage = () => {
-  const [to, setTo] = useState("");
+  const [toInputValue, setToInputValue] = useState("");
   const [toError, setToError] = useState("");
   const [background, setBackground] = useState({
     backgroundColor: undefined,
@@ -44,33 +44,49 @@ const PostCreatePage = () => {
     } else {
       setToError("");
     }
-    setTo(value);
+    setToInputValue(value);
   };
 
   const handleBlur = () => {
-    if (to.trim() === "") {
+    if (toInputValue.trim() === "") {
       setToError("값을 입력해 주세요");
-    } else if (to.length > MAX_TO_LENGTH) {
+    } else if (toInputValue.length > MAX_TO_LENGTH) {
       setToError(`이름은 ${MAX_TO_LENGTH}자 이상 입력할 수 없어요.`);
     } else {
       setToError("");
     }
   };
 
-  const handleCreate = () => {
-    if (to.trim() === "") {
+  const handleCreatePostPage = async () => {
+    if (toInputValue.trim() === "") {
       setToError("값을 입력해 주세요");
       return;
     }
 
-    const fakeId = "test123";
-    navigate(`/post/${fakeId}`);
+    const formData = {
+      name: toInputValue,
+      backgroundColor: isBackgroundSelected,
+      backgroundImageURL: isBackgroundSelected,
+    };
+
+    try {
+      const result = await createRecipient(formData);
+      console.log("롤링페이퍼 생성 성공!: ", result);
+    } catch (err) {
+      console.log(err.message);
+    }
+
+    // navigate(`/post/${fakeId}`);
   };
 
   const isBackgroundSelected =
     background.backgroundColor || background.backgroundImageURL;
 
-  const isCreateEnabled = to.trim() !== "" && isBackgroundSelected;
+  const isCreateEnabled = toInputValue.trim() !== "" && isBackgroundSelected;
+
+  useEffect(() => {
+    console.log(isBackgroundSelected);
+  }, [isBackgroundSelected]);
 
   return (
     <div>
@@ -81,7 +97,7 @@ const PostCreatePage = () => {
       <Container>
         <Label value="To." />
         <Input
-          value={to}
+          value={toInputValue}
           onChange={handleChange}
           onBlur={handleBlur}
           placeholder="받는사람 이름을 입력해 주세요"
@@ -89,13 +105,6 @@ const PostCreatePage = () => {
           maxLength={MAX_TO_LENGTH}
           autoFocus
         />
-        {/* <ToInput
-          value={to}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          placeholder="받는사람 이름을 입력해 주세요"
-          error={toError}
-        /> */}
 
         <Background>
           <SelectBackground onChange={setBackground} />
@@ -106,7 +115,7 @@ const PostCreatePage = () => {
             variant="primary"
             size="lg"
             disabled={!isCreateEnabled}
-            onClick={handleCreate}
+            onClick={handleCreatePostPage}
             style={{ width: "100%" }}
           >
             생성하기

--- a/src/pages/Post/PostCreate/PostCreatePage.jsx
+++ b/src/pages/Post/PostCreate/PostCreatePage.jsx
@@ -27,11 +27,20 @@ const HeaderWrapper = styled.div`
 
 const MAX_TO_LENGTH = 20;
 
+// 백그라운드 컬러
+const BackgroundColor = {
+  beige: "#FFE2AD",
+  purple: "#ECD9FF",
+  blue: "#B1E4FF",
+  green: "#D0F5C3",
+};
+const AVAILABLE_COLORS = Object.keys(BackgroundColor);
+
 const PostCreatePage = () => {
   const [toInputValue, setToInputValue] = useState("");
   const [toError, setToError] = useState("");
   const [background, setBackground] = useState({
-    backgroundColor: undefined,
+    backgroundColor: AVAILABLE_COLORS[0],
     backgroundImageURL: undefined,
   });
 
@@ -64,29 +73,25 @@ const PostCreatePage = () => {
     }
 
     const formData = {
+      team: "16-7",
       name: toInputValue,
-      backgroundColor: isBackgroundSelected,
-      backgroundImageURL: isBackgroundSelected,
+      backgroundColor: background.backgroundColor,
+      backgroundImageURL: background.backgroundImageURL,
     };
 
     try {
       const result = await createRecipient(formData);
       console.log("롤링페이퍼 생성 성공!: ", result);
+      navigate(`/post/${result.id}`);
     } catch (err) {
       console.log(err.message);
     }
-
-    // navigate(`/post/${fakeId}`);
   };
 
   const isBackgroundSelected =
     background.backgroundColor || background.backgroundImageURL;
 
   const isCreateEnabled = toInputValue.trim() !== "" && isBackgroundSelected;
-
-  useEffect(() => {
-    console.log(isBackgroundSelected);
-  }, [isBackgroundSelected]);
 
   return (
     <div>

--- a/src/pages/Post/components/SelectBackground.jsx
+++ b/src/pages/Post/components/SelectBackground.jsx
@@ -50,7 +50,7 @@ const ColorList = styled.div`
   }
 `;
 
-const ColorOption = styled.button`
+const ColorOption = styled.div`
   width: 100%;
   aspect-ratio: 1 / 1;
   border-radius: 12px;
@@ -75,7 +75,7 @@ const ImageList = styled.div`
 `;
 
 // ImageOption: 이미지 + 클릭 영역통합
-const ImageOption = styled.button`
+const ImageOption = styled.div`
   width: 100%;
   aspect-ratio: 1 / 1;
   padding: 0;
@@ -84,7 +84,7 @@ const ImageOption = styled.button`
   cursor: pointer;
   position: relative;
 
-  img {
+  > img {
     width: 100%;
     height: 100%;
     object-fit: cover;

--- a/src/pages/Post/components/SelectBackground.jsx
+++ b/src/pages/Post/components/SelectBackground.jsx
@@ -54,7 +54,7 @@ const ColorOption = styled.div`
   width: 100%;
   aspect-ratio: 1 / 1;
   border-radius: 12px;
-  border: ${({ selected }) => (selected ? "2px solid blue" : "1px solid #ccc")};
+  border: transparent;
   background-color: ${({ color }) => color};
   cursor: pointer;
   transition: filter 0.3s ease;

--- a/src/pages/Post/components/SelectBackground.jsx
+++ b/src/pages/Post/components/SelectBackground.jsx
@@ -4,13 +4,135 @@ import { getImages } from "../../../api";
 import { IconCheckButton } from "../../../components/Button/IconButtons";
 
 // 백그라운드 컬러
-const Background_Color = {
+const BackgroundColor = {
   beige: "#FFE2AD",
   purple: "#ECD9FF",
   blue: "#B1E4FF",
   green: "#D0F5C3",
 };
-const AVAILABLE_COLORS = Object.keys(Background_Color);
+const AVAILABLE_COLORS = Object.keys(BackgroundColor);
+
+// 컴포넌트 본문
+const SelectBackground = ({ onChange }) => {
+  const [images, setImages] = useState([]);
+  const [selectedColor, setSelectedColor] = useState("");
+  const [selectedImage, setSelectedImage] = useState("");
+  const [mode, setMode] = useState("color");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const imagesData = await getImages();
+      if (Array.isArray(imagesData)) setImages(imagesData);
+    };
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedColor && mode === "color") {
+      const firstColor = AVAILABLE_COLORS[0];
+      setSelectedColor(firstColor);
+      onChange?.({
+        backgroundColor: firstColor,
+        backgroundImageURL: undefined,
+      });
+    } else if (!selectedImage && mode === "image" && images.length > 0) {
+      const firstImage = images[0];
+      if (selectedImage !== firstImage) {
+        setSelectedImage(firstImage);
+        onChange?.({
+          backgroundColor: undefined,
+          backgroundImageURL: firstImage,
+        });
+      }
+    }
+  }, [selectedColor, selectedImage, mode, images, onChange]);
+
+  const handleColorClick = (color) => {
+    setSelectedColor(color);
+    setSelectedImage("");
+    onChange?.({ backgroundColor: color, backgroundImageURL: undefined });
+  };
+
+  const handleImageClick = (url) => {
+    setSelectedImage(url);
+    setSelectedColor("");
+    onChange?.({ backgroundColor: undefined, backgroundImageURL: url });
+  };
+
+  const handleChangeMode = (mode) => {
+    setMode(mode);
+    if (mode === "color") {
+      setSelectedImage("");
+    }
+    if (mode === "image") {
+      setSelectedColor("");
+    }
+  };
+
+  return (
+    <div>
+      <BackgroundLabel>배경화면을 선택해 주세요.</BackgroundLabel>
+      <SubText>컬러를 선택하거나, 이미지를 선택할 수 있습니다.</SubText>
+
+      <ToggleButtons>
+        <button
+          onClick={() => handleChangeMode("color")}
+          className={mode === "color" ? "active" : ""}
+        >
+          컬러
+        </button>
+        <button
+          onClick={() => handleChangeMode("image")}
+          className={mode === "image" ? "active" : ""}
+        >
+          이미지
+        </button>
+      </ToggleButtons>
+
+      <TabsContentWrapper>
+        {mode === "color" && (
+          <ColorList>
+            {AVAILABLE_COLORS.map((color) => (
+              <ColorOption
+                key={color}
+                color={BackgroundColor[color]}
+                selected={selectedColor === color}
+                onClick={() => handleColorClick(color)}
+              >
+                {selectedColor === color && (
+                  <CheckIconWrapper>
+                    <IconCheckButton />
+                  </CheckIconWrapper>
+                )}
+              </ColorOption>
+            ))}
+          </ColorList>
+        )}
+
+        {mode === "image" && (
+          <ImageList>
+            {images.map((url, idx) => (
+              <ImageOption
+                key={idx}
+                onClick={() => handleImageClick(url)}
+                selected={selectedImage === url}
+              >
+                <img src={url} alt="" />
+                {selectedImage === url && (
+                  <CheckIconWrapper>
+                    <IconCheckButton />
+                  </CheckIconWrapper>
+                )}
+              </ImageOption>
+            ))}
+          </ImageList>
+        )}
+      </TabsContentWrapper>
+    </div>
+  );
+};
+
+export default SelectBackground;
 
 // 스타일 컴포넌트
 const TabsContentWrapper = styled.div`
@@ -117,106 +239,3 @@ const SubText = styled.p`
   font-weight: var(--font-weight-regular);
   margin: 0px 0px 24px;
 `;
-
-// 컴포넌트 본문
-const SelectBackground = ({ onChange }) => {
-  const [images, setImages] = useState([]);
-  const [selectedColor, setSelectedColor] = useState("");
-  const [selectedImage, setSelectedImage] = useState("");
-  const [mode, setMode] = useState("color");
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const imagesData = await getImages();
-      if (Array.isArray(imagesData)) setImages(imagesData);
-    };
-    fetchData();
-  }, []);
-
-  useEffect(() => {
-    if (!selectedColor && !selectedImage && mode === "color") {
-      const firstColor = AVAILABLE_COLORS[0];
-      setSelectedColor(firstColor);
-      onChange?.({
-        backgroundColor: firstColor,
-        backgroundImageURL: undefined,
-      });
-    }
-  }, [selectedColor, selectedImage, mode, onChange]);
-
-  const handleColorClick = (color) => {
-    setSelectedColor(color);
-    setSelectedImage("");
-    onChange?.({ backgroundColor: color, backgroundImageURL: undefined });
-  };
-
-  const handleImageClick = (url) => {
-    setSelectedImage(url);
-    setSelectedColor("");
-    onChange?.({ backgroundColor: undefined, backgroundImageURL: url });
-  };
-
-  return (
-    <div>
-      <BackgroundLabel>배경화면을 선택해 주세요.</BackgroundLabel>
-      <SubText>컬러를 선택하거나, 이미지를 선택할 수 있습니다.</SubText>
-
-      <ToggleButtons>
-        <button
-          onClick={() => setMode("color")}
-          className={mode === "color" ? "active" : ""}
-        >
-          컬러
-        </button>
-        <button
-          onClick={() => setMode("image")}
-          className={mode === "image" ? "active" : ""}
-        >
-          이미지
-        </button>
-      </ToggleButtons>
-
-      <TabsContentWrapper>
-        {mode === "color" && (
-          <ColorList>
-            {AVAILABLE_COLORS.map((color) => (
-              <ColorOption
-                key={color}
-                color={Background_Color[color]}
-                selected={selectedColor === color}
-                onClick={() => handleColorClick(color)}
-              >
-                {selectedColor === color && (
-                  <CheckIconWrapper>
-                    <IconCheckButton />
-                  </CheckIconWrapper>
-                )}
-              </ColorOption>
-            ))}
-          </ColorList>
-        )}
-
-        {mode === "image" && (
-          <ImageList>
-            {images.map((url, idx) => (
-              <ImageOption
-                key={idx}
-                onClick={() => handleImageClick(url)}
-                selected={selectedImage === url}
-              >
-                <img src={url} alt="" />
-                {selectedImage === url && (
-                  <CheckIconWrapper>
-                    <IconCheckButton />
-                  </CheckIconWrapper>
-                )}
-              </ImageOption>
-            ))}
-          </ImageList>
-        )}
-      </TabsContentWrapper>
-    </div>
-  );
-};
-
-export default SelectBackground;

--- a/src/pages/Post/components/SelectBackground.jsx
+++ b/src/pages/Post/components/SelectBackground.jsx
@@ -90,8 +90,8 @@ const ImageOption = styled.div`
     object-fit: cover;
     border-radius: 12px;
     display: block;
-    transition: filter 0.3s ease;
-    filter: ${({ selected }) => (selected ? "brightness(120%)" : "none")};
+    transition: opacity 0.3s ease;
+    opacity: ${({ selected }) => (selected ? "0.3" : "1")};
   }
 `;
 

--- a/src/pages/Post/components/SelectBackground.jsx
+++ b/src/pages/Post/components/SelectBackground.jsx
@@ -11,11 +11,13 @@ const BackgroundColor = {
   green: "#D0F5C3",
 };
 const AVAILABLE_COLORS = Object.keys(BackgroundColor);
+const FIRST_COLOR = AVAILABLE_COLORS[0];
 
 // 컴포넌트 본문
 const SelectBackground = ({ onChange }) => {
   const [images, setImages] = useState([]);
-  const [selectedColor, setSelectedColor] = useState("");
+  const [firstImage, setFirstImage] = useState("");
+  const [selectedColor, setSelectedColor] = useState(FIRST_COLOR);
   const [selectedImage, setSelectedImage] = useState("");
   const [mode, setMode] = useState("color");
 
@@ -23,50 +25,44 @@ const SelectBackground = ({ onChange }) => {
     const fetchData = async () => {
       const imagesData = await getImages();
       if (Array.isArray(imagesData)) setImages(imagesData);
+
+      // 배경/컬러 미설정시 기본값으로 첫번째 값 전송 (api 유효값 설정용)
+      setSelectedColor(FIRST_COLOR);
+      const firstImage = imagesData[0];
+      setFirstImage(firstImage);
+      setSelectedImage(firstImage);
+
+      onChange?.({
+        backgroundColor: FIRST_COLOR,
+        backgroundImageURL: firstImage,
+      });
     };
     fetchData();
-  }, []);
-
-  useEffect(() => {
-    if (!selectedColor && mode === "color") {
-      const firstColor = AVAILABLE_COLORS[0];
-      setSelectedColor(firstColor);
-      onChange?.({
-        backgroundColor: firstColor,
-        backgroundImageURL: undefined,
-      });
-    } else if (!selectedImage && mode === "image" && images.length > 0) {
-      const firstImage = images[0];
-      if (selectedImage !== firstImage) {
-        setSelectedImage(firstImage);
-        onChange?.({
-          backgroundColor: undefined,
-          backgroundImageURL: firstImage,
-        });
-      }
-    }
-  }, [selectedColor, selectedImage, mode, images, onChange]);
+  }, [onChange]);
 
   const handleColorClick = (color) => {
     setSelectedColor(color);
-    setSelectedImage("");
-    onChange?.({ backgroundColor: color, backgroundImageURL: undefined });
+    onChange?.({ backgroundColor: color, backgroundImageURL: selectedImage });
   };
 
   const handleImageClick = (url) => {
     setSelectedImage(url);
-    setSelectedColor("");
-    onChange?.({ backgroundColor: undefined, backgroundImageURL: url });
+    onChange?.({ backgroundColor: selectedColor, backgroundImageURL: url });
   };
 
-  const handleChangeMode = (mode) => {
-    setMode(mode);
-    if (mode === "color") {
-      setSelectedImage("");
+  const handleChangeMode = (newMode) => {
+    setMode(newMode);
+
+    if (newMode === "color") {
+      setSelectedColor(FIRST_COLOR);
+    } else if (newMode === "image" && images.length > 0) {
+      setSelectedImage(firstImage);
     }
-    if (mode === "image") {
-      setSelectedColor("");
-    }
+
+    onChange?.({
+      backgroundColor: FIRST_COLOR,
+      backgroundImageURL: firstImage,
+    });
   };
 
   return (

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -2,7 +2,7 @@ import { Routes, Route } from "react-router-dom";
 import MainPage from "../pages/Main/components/MainPage.jsx";
 import ListPage from "../pages/List/ListPage";
 import StyleGuidePage from "../pages/StyleGuide/StyleGuidePage";
-import PostCreatePage from "../pages/Post/PostCreatePage.jsx";
+import PostCreatePage from "../pages/Post/PostCreate/PostCreatePage.jsx";
 import PostMessagePage from "../pages/Post/PostMessage/PostMessagePage.jsx";
 import PostDetailPage from "../pages/Post/PostDetail/PostDetailPage.jsx";
 


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 롤링페이퍼 생성 페이지: '생성하기' 클릭 시 폼 데이터 api post 성공 → 새로운 롤링페이퍼 생성

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- post 후 생성된 롤링페이퍼 페이지(`PostMessagePage`)에 `배경 스타일` 데이터, `수신인` 데이터 추가 연동이 필요할 것 같습니다.

## 📸스크린샷 (선택)
### 생성 후 `/post/{id}` 페이지
![제목 없음](https://github.com/user-attachments/assets/34d62ee4-c3e0-472f-a9f2-87a71d518887)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).