### PR TITLE
[1차 QA 반영] 뷰포트 변경 시 페이지네이션 안 보이는 에러 수정/ 반응형 훅 이름 수정/ listpage 하단 cta 버튼 패딩 수

### DIFF
--- a/src/pages/List/ListPage.jsx
+++ b/src/pages/List/ListPage.jsx
@@ -143,4 +143,8 @@ const ctaWrapper = css`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  @media (min-width: ${BREAKPOINTS.lg}px) {
+    padding-bottom: 48px;
+  }
 `;

--- a/src/pages/List/Slider.jsx
+++ b/src/pages/List/Slider.jsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { useState, useRef } from "react";
 import { Link } from "react-router-dom";
-import useBreakpoint from "./hooks/useResponsive";
+import useResponsive from "./hooks/useResponsive";
 import Pagination from "./Pagination";
 import {
   BREAKPOINTS,
@@ -30,7 +30,7 @@ const SETTINGS = {
 
 const Slider = ({ items }) => {
   // 뷰포트에 따른 설정 가져오기
-  const breakpoint = useBreakpoint();
+  const breakpoint = useResponsive();
   const { cardWidth, visibleCount } = SETTINGS[breakpoint] || SETTINGS.desktop;
 
   // 슬라이드 범위 계산

--- a/src/pages/List/hooks/useResponsive.jsx
+++ b/src/pages/List/hooks/useResponsive.jsx
@@ -8,19 +8,15 @@ const getBreakpoint = () => {
   return "mobile";
 };
 
-const useBreakpoint = () => {
+const useResponsive = () => {
   const [breakpoint, setBreakpoint] = useState(getBreakpoint());
 
   useEffect(() => {
     const handleResize = () => {
-      const next = getBreakpoint();
-      if (next !== breakpoint) {
-        setBreakpoint(next);
-      }
+      setBreakpoint(getBreakpoint());
     };
 
     window.addEventListener("resize", handleResize);
-
     return () => {
       window.removeEventListener("resize", handleResize);
     };
@@ -28,4 +24,4 @@ const useBreakpoint = () => {
   return breakpoint;
 };
 
-export default useBreakpoint;
+export default useResponsive;


### PR DESCRIPTION
## 📝 요약(Summary)
- useBreakpoint -> useResponsive 훅 이름을 파일명과 동일하게 수정했습니다
- LIstPage에서 cta버튼 하단에 여백을 추가했습니다.
- 모바일,태블릿에서 데스크탑으로 뷰포트 변경 시 페이지네이션이 안 보이는 에러 수정하였습니다
   - resize 이벤트 핸들러가 breakpoint의 초기값만 참조해서 생긴 문제
   - 핸들러 안에서 항상 최신 상태를 기준으로 동작하게 수정

## 💬 공유사항 to 리뷰어


## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).