### PR TITLE
fix: MessageAuthorCount is not iterable 에러 수정 (messages에 기본값 추가)

### DIFF
--- a/src/components/MessageAuthorCount/MessageAuthorCount.jsx
+++ b/src/components/MessageAuthorCount/MessageAuthorCount.jsx
@@ -2,8 +2,8 @@ import { css } from "@emotion/react";
 import AvatarList from "../Avatar/AvatarList";
 import { extractUniqueSenders } from "../../utils/extractUniqueSenders";
 
-const MessageAuthorCount = ({ messages, customStyle }) => {
-   const items = extractUniqueSenders(messages);
+const MessageAuthorCount = ({ messages = [], customStyle }) => {
+  const items = extractUniqueSenders(messages);
 
   if (!items || items.length === 0) return null;
 


### PR DESCRIPTION
## 📝 요약(Summary)
-MessageAuthorCount에 방어코딩을 추가하여 에러를 막았습니다

## 💬 공유사항 to 리뷰어


## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).