### PR TITLE
Style: 롤링페이퍼 페이지 배경 이미지 dimmed, 액션 버튼 shadow 추가

### DIFF
--- a/src/pages/Post/PostDetail/MessageActionButtons.jsx
+++ b/src/pages/Post/PostDetail/MessageActionButtons.jsx
@@ -35,6 +35,10 @@ const ButtonGroupStyle = css`
   justify-content: flex-end;
   gap: 10px;
   margin: 0 0 16px 0;
+
+  button {
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+  }
 `;
 
 export default MessageActionButtons;

--- a/src/pages/Post/PostDetail/MessagesPage.jsx
+++ b/src/pages/Post/PostDetail/MessagesPage.jsx
@@ -48,6 +48,7 @@ const MessagesPage = () => {
 };
 
 const MessagesPageStyle = ({ recipient }) => css`
+  position: relative;
   min-height: 100vh;
   background-color: ${BACKGROUND_COLORS[recipient?.backgroundColor] || "#fff"};
 
@@ -58,6 +59,19 @@ const MessagesPageStyle = ({ recipient }) => css`
     background-position: center;
     background-size: cover;
   `}
+
+  &:before {
+    content: "";
+    position: absolute;
+    z-index: 0;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    ${recipient?.backgroundImageURL && "display: block"};
+  }
 
   .messages-container {
     position: relative;


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 롤링페이퍼 페이지의 메시지 카드와 액션 버튼의 가시성을 높이기 위한 스타일 수정

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📸스크린샷 (선택)
### dimmed, button box-shadow 적용 전
![스크린샷 2025-06-10 오후 2 51 50](https://github.com/user-attachments/assets/6abc3a62-9e33-46fc-b1e6-4c4665b59dea)

### 적용 후
![스크린샷 2025-06-10 오후 2 51 34](https://github.com/user-attachments/assets/93dedfb7-cd8c-4f29-9d8f-944ea8fce0ef)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).