### PR TITLE
Feature: 페이지 이동 시 스크롤 최상단으로 이동 (무한스크롤 페이지, 리스트 페이지 제외)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,9 +2,11 @@ import { css } from "@emotion/react";
 import Router from "./routes/Router";
 import LoadingPage from "./pages/LoadingPage";
 import usePageLoadTransition from "./hooks/usePageLoadTransition";
+import useScrollToTop from "./hooks/useScrollToTop";
 
 function App() {
   const { isPageLoading, showLoadingUI, fadeIn } = usePageLoadTransition();
+  useScrollToTop();
 
   if (isPageLoading) {
     return <LoadingPage showLoading={showLoadingUI} />;

--- a/src/hooks/useScrollToTop.js
+++ b/src/hooks/useScrollToTop.js
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { matchPath, useLocation } from "react-router-dom";
+
+const useScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const excludedPaths = ["/list", "/post/:id"];
+    const shouldExclude = excludedPaths.some((path) =>
+      matchPath(path, pathname)
+    );
+
+    // 무한 스크롤 사용 페이지, 페이지 내부 앵커 클릭의 경우에는 제외
+    if (!shouldExclude && !window.location.hash) {
+      window.scrollTo(0, 0);
+    }
+  }, [pathname]);
+};
+
+export default useScrollToTop;


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 폼 작성 페이지로 이동할 때 스크롤 위치가 애매한 곳에서 시작되는 경우가 있어서 ux 개선을 위해 해당 기능 추가
- 무한 스크롤이 있는 `/post/:id` 페이지, 이 페이지와 연결되는 `/list` 페이지는 해당 기능 제외

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).