### PR TITLE
Feature: 페이지 이동 시 모달 닫기

### DIFF
--- a/src/components/Modal/ModalProvider.jsx
+++ b/src/components/Modal/ModalProvider.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { nanoid } from "nanoid";
 import ModalContext from "./ModalContext";
 import ModalContainer from "../Modal/ModalContainer";
+import { useLocation } from "react-router-dom";
 
 const MODAL_VISIBLE_MS = 300;
 const MODAL_DELETE_DOM_MS = 300;
@@ -9,6 +10,8 @@ const MODAL_ANIM_READY_MS = 10;
 
 const ModalProvider = ({ children }) => {
   const [modals, setModals] = useState([]);
+  const modalsRef = useRef([]); // 무한 루프 방지용
+  const location = useLocation(); // 페이지 이동 시 모달 닫기용
 
   const setModalsVisibleFn = ({ id, visible }) => {
     return setModals((prev) =>
@@ -29,7 +32,7 @@ const ModalProvider = ({ children }) => {
     }, MODAL_ANIM_READY_MS);
   };
 
-  const hideModal = (id) => {
+  const hideModal = useCallback((id) => {
     // Step 1: visible 상태만 false로 업데이트 → 퇴장 애니메이션 트리거
     setModalsVisibleFn({ id, visible: false });
 
@@ -37,8 +40,9 @@ const ModalProvider = ({ children }) => {
     setTimeout(() => {
       setModals((prev) => prev.filter((modal) => modal.id !== id));
     }, MODAL_VISIBLE_MS + MODAL_DELETE_DOM_MS);
-  };
+  }, []);
 
+  // 모달 열려있으면 스크롤 잠금
   useEffect(() => {
     if (modals.some((modal) => modal.visible)) {
       document.body.style.overflow = "hidden";
@@ -50,6 +54,22 @@ const ModalProvider = ({ children }) => {
       document.body.style.overflow = "";
     };
   }, [modals]);
+
+  // ref로 최신 modals 상태 저장
+  useEffect(() => {
+    modalsRef.current = modals;
+  }, [modals]);
+
+  // 페이지 이동 시 모든 모달 닫기
+  const hideAllModals = useCallback(() => {
+    modalsRef.current.forEach((modal) => {
+      hideModal(modal.id);
+    });
+  }, [hideModal]);
+
+  useEffect(() => {
+    hideAllModals();
+  }, [location, hideAllModals]);
 
   return (
     <ModalContext.Provider value={{ modals, showModal, hideModal }}>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,15 +10,15 @@ import ModalProvider from "./components/Modal/ModalProvider.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <ModalProvider>
-      <ToastProvider>
-        <Reset />
-        <Variables />
-        <Fonts />
-        <BrowserRouter>
+    <BrowserRouter>
+      <ModalProvider>
+        <ToastProvider>
+          <Reset />
+          <Variables />
+          <Fonts />
           <App />
-        </BrowserRouter>
-      </ToastProvider>
-    </ModalProvider>
+        </ToastProvider>
+      </ModalProvider>
+    </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 롤링페이퍼 페이지에서 모달을 열어놓고 페이지를 이동하면 모달이 계속 열려있는 현상 수정
- `ModalContext.Provider`에서 `useLocation`을 사용하기 위해 `Router` 구조를 수정했습니다.
  - `BrowserRouter`를 라우터 최상위로 이동
  - 구조적으로도 `BrowserRouter`가 최상위에 위치하는 게 좋다고 하네요..

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📸스크린샷 (선택)
### 수정 전
- 페이지를 이동해도 띄워놨던 모달이 계속 남아있어서 페이지를 가림
![스크린샷 2025-06-11 오후 1 28 10](https://github.com/user-attachments/assets/c28406fa-5444-45dd-8fd4-4ab1c826dc69)
### 수정 후

https://github.com/user-attachments/assets/7906b437-28bb-4caf-addc-d227be7f0dc3




## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).