### PR TITLE
refactor: useMessagesPage훅에서 처리하기 보다 iu구분을 위해 MessageActionButtons에서 …

### DIFF
--- a/src/pages/Post/PostDetail/MessageActionButtons.jsx
+++ b/src/pages/Post/PostDetail/MessageActionButtons.jsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import Button from "../../../components/Button";
 import { useMessages } from "../context/MessagesContext";
 import useModal from "../../../components/Modal/useModal";
-import { useContext } from "react";
+import { useContext, useEffect, useRef } from "react";
 import ToastContext from "../../../components/Toast/ToastContext";
 import ConfirmModal from "../../../components/Modal/ConfirmModal";
 
@@ -13,10 +13,12 @@ const MessageActionButtons = () => {
     handleDeleteSelected,
     handleEditButton,
     handleToggleSelectAll,
+    setSelectedIds,
   } = useMessages();
 
   const { showModal, hideModal } = useModal();
   const { showToast } = useContext(ToastContext);
+  const prevEditModeRef = useRef(editMode);
 
   const onDeleteRequest = () => {
     const modalId = showModal(
@@ -36,15 +38,22 @@ const MessageActionButtons = () => {
     );
   };
 
-  const onEditToggle = () => {
-    handleEditButton();
-    showToast({
-      state: "success",
-      message: editMode
-        ? "편집 모드를 종료했습니다."
-        : "편집 모드를 시작했습니다.",
-    });
-  };
+  useEffect(() => {
+    if (prevEditModeRef.current !== editMode) {
+      showToast({
+        state: "success",
+        message: editMode
+          ? "편집 모드를 시작했습니다."
+          : "편집 모드를 종료했습니다.",
+      });
+
+      if (!editMode) {
+        setSelectedIds([]);
+      }
+
+      prevEditModeRef.current = editMode;
+    }
+  }, [editMode]);
 
   return (
     <div css={ButtonGroupStyle}>
@@ -56,10 +65,10 @@ const MessageActionButtons = () => {
           <Button onClick={onDeleteRequest} disabled={!selectedIds.length}>
             🗑 선택 삭제 ({selectedIds.length}개)
           </Button>
-          <Button onClick={onEditToggle}>❌ 편집 종료</Button>
+          <Button onClick={handleEditButton}>❌ 편집 종료</Button>
         </>
       ) : (
-        <Button onClick={onEditToggle}>✏️ 편집하기</Button>
+        <Button onClick={handleEditButton}>✏️ 편집하기</Button>
       )}
     </div>
   );

--- a/src/pages/Post/hooks/useMessagesPage.js
+++ b/src/pages/Post/hooks/useMessagesPage.js
@@ -43,15 +43,8 @@ const useMessagesPage = () => {
     }
   }, [recipientId]);
 
-  useEffect(() => {
-    if (!editMode) {
-      setSelectedIds([]);
-    }
-  }, [editMode]);
-
   const handleEditButton = () => {
     const baseUrl = `/post/${recipientId}`;
-    setSelectedIds([]);
     navigate(editMode ? baseUrl : `${baseUrl}/edit`);
   };
 


### PR DESCRIPTION
…처리하기(언마운트시 선택해제 및 토스트 출력)

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
useMessagesPage 훅에서 처리하던 언마운트시 선택해제 로직을 토스트와 함께 한번에 처리하기 위해서 MessageActionButton 컴포넌트로 이동,
useRef를 이용해 editMode의 변화를 감지해서 동작하도록 로직 수정
=showToast와 selectedIds를 한번에 처리.

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).