### PR TITLE
Fix: 메시지 작성 페이지 - 기본 프로필 이미지 사용 시 메시지 작성 안되는 에러 수정

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -83,3 +83,6 @@ export const BACKGROUND_MODES_MAP = {
   컬러: "color",
   이미지: "image",
 };
+
+export const DEFAULT_PROFILE_IMAGE_URL =
+  "https://ucarecdn.com/82005ae5-e2dc-4835-9de6-ad51ee3dc6a9/-/preview/80x80/";

--- a/src/hooks/useScrollToTop.js
+++ b/src/hooks/useScrollToTop.js
@@ -5,7 +5,7 @@ const useScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    const excludedPaths = ["/list", "/post/:id"];
+    const excludedPaths = ["/post/:id"];
     const shouldExclude = excludedPaths.some((path) =>
       matchPath(path, pathname)
     );

--- a/src/pages/Post/PostMessage/PostMessagePage.jsx
+++ b/src/pages/Post/PostMessage/PostMessagePage.jsx
@@ -13,6 +13,7 @@ import {
   FONTS_ITEMS,
   BREAKPOINTS,
   NAME_MAX_LENGTH,
+  DEFAULT_PROFILE_IMAGE_URL,
 } from "../../../constants/constants";
 import SelectProfileImage from "./SelectProfileImage";
 import useBreakpoint from "../../List/hooks/useResponsive";
@@ -25,7 +26,9 @@ const PostMessagePage = () => {
   const [fromInputError, setFromInputError] = useState("");
 
   // 프로필 이미지 선택
-  const [profileImageSrc, setProfileImageSrc] = useState("");
+  const [profileImageSrc, setProfileImageSrc] = useState(
+    DEFAULT_PROFILE_IMAGE_URL
+  );
 
   // 관계 선택
   const [relationshipValue, setRelationshipValue] = useState(
@@ -281,6 +284,7 @@ const PostMessageFormStyle = ({ messageValueError }) => css`
   .ql-editor {
     min-height: 200px;
     font-size: var(--font-size-16);
+    cursor: text;
   }
 `;
 


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- assets 폴더 안에 있는 기본 이미지를 상대 경로로 받아와서 api 요청 보내면 유효한 주소값(cdn url)이 아니라서 요청 실패.
- uploadcare에 기본 이미지 파일 업로드하고, cdn url 주소 받아와서 상수화 후 적용

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).